### PR TITLE
feat: Add PulseWatch polyglot microservices

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# PulseWatch Environment Variables
+
+# Service Ports
+GATEWAY_PORT=3000
+CHECKER_PORT=8080
+ANALYTICS_PORT=5000
+
+# Service URLs (used when running outside Docker)
+CHECKER_URL=http://localhost:8080
+ANALYTICS_URL=http://localhost:5000
+
+# Logging
+LOG_LEVEL=INFO

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,50 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+dist/
+build/
+.eggs/
+*.egg
+.venv/
+venv/
+.pytest_cache/
+
+# Go
+services/checker/checker
+*.exe
+*.test
+*.out
+
+# TypeScript / Node
+node_modules/
+services/gateway/dist/
+*.js.map
+*.d.ts
+!jest.config.js
+!.eslintrc.json
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Docker
+.docker/
+
+# Coverage
+htmlcov/
+.coverage
+coverage/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+.PHONY: test test-python test-go test-ts lint up down build clean
+
+## Run all tests
+test: test-python test-go test-ts
+
+## Run Python tests
+test-python:
+	cd services/analytics && pip install -q -r requirements.txt && pytest -v
+
+## Run Go tests
+test-go:
+	cd services/checker && go test -v ./...
+
+## Run TypeScript tests
+test-ts:
+	cd services/gateway && npm install --silent && npm test
+
+## Run all linters
+lint: lint-python lint-go lint-ts
+
+## Lint Python
+lint-python:
+	cd services/analytics && pip install -q -r requirements.txt && flake8 --max-line-length=120 app.py
+
+## Lint Go
+lint-go:
+	cd services/checker && go vet ./...
+
+## Lint TypeScript
+lint-ts:
+	cd services/gateway && npm install --silent && npx eslint src/ --ext .ts
+
+## Start all services with Docker Compose
+up:
+	docker compose up --build -d
+
+## Stop all services
+down:
+	docker compose down
+
+## Build all Docker images
+build:
+	docker compose build
+
+## Remove all containers, images, and volumes
+clean:
+	docker compose down --rmi all --volumes --remove-orphans

--- a/README.md
+++ b/README.md
@@ -1,1 +1,239 @@
 # PulseWatch
+
+Real-time API health monitoring platform with polyglot microservices.
+
+PulseWatch lets you register API endpoints, run health checks against them, and view uptime analytics and performance reports — all through a unified gateway API.
+
+## Architecture
+
+```mermaid
+graph TB
+    Client[Client / Browser] --> Gateway
+
+    subgraph PulseWatch
+        Gateway["Gateway Service<br/>(TypeScript / Express)<br/>:3000"]
+        Checker["Checker Service<br/>(Go / net/http)<br/>:8080"]
+        Analytics["Analytics Service<br/>(Python / Flask)<br/>:5000"]
+    end
+
+    Gateway -->|Register & Check endpoints| Checker
+    Gateway -->|Query records & reports| Analytics
+    Checker -->|Report results| Analytics
+    Checker -->|HTTP health checks| ExtAPI[External APIs]
+
+    style Gateway fill:#3178c6,color:#fff
+    style Checker fill:#00add8,color:#fff
+    style Analytics fill:#3776ab,color:#fff
+```
+
+### Services
+
+| Service | Language | Port | Description |
+|---------|----------|------|-------------|
+| **Gateway** | TypeScript (Express) | 3000 | API gateway — routes requests to backend services, aggregates health status |
+| **Checker** | Go (net/http) | 8080 | Performs health checks on registered endpoints, reports results to Analytics |
+| **Analytics** | Python (Flask) | 5000 | Stores health check records, generates uptime and performance reports |
+
+## Quick Start
+
+### Prerequisites
+
+- Docker & Docker Compose
+- (For local development) Python 3.12+, Go 1.22+, Node.js 20+
+
+### Run with Docker Compose
+
+```bash
+# Clone the repository
+git clone https://github.com/mohadayo/pulsewatch.git
+cd pulsewatch
+
+# Copy environment file
+cp .env.example .env
+
+# Start all services
+make up
+# or
+docker compose up --build -d
+```
+
+### Run Tests
+
+```bash
+# All tests
+make test
+
+# Individual services
+make test-python
+make test-go
+make test-ts
+
+# Linting
+make lint
+```
+
+## API Reference
+
+All endpoints are accessible through the Gateway at `http://localhost:3000`.
+
+### Health Checks
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/health` | Gateway health check |
+| `GET` | `/api/v1/status` | Aggregated health status of all services |
+
+### Endpoint Management
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api/v1/endpoints` | List all registered endpoints |
+| `POST` | `/api/v1/endpoints` | Register a new endpoint |
+
+**POST /api/v1/endpoints** body:
+```json
+{
+  "url": "https://api.example.com/health",
+  "name": "Example API"
+}
+```
+
+### Health Check Operations
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/api/v1/check` | Check a single URL |
+| `POST` | `/api/v1/check-all` | Check all registered endpoints |
+
+**POST /api/v1/check** body:
+```json
+{
+  "url": "https://api.example.com/health"
+}
+```
+
+### Analytics
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api/v1/records` | List health check records |
+| `GET` | `/api/v1/records?endpoint=URL&limit=N` | Filter records by endpoint |
+| `GET` | `/api/v1/report` | Get uptime and performance report |
+
+### Usage Examples
+
+```bash
+# Register an endpoint
+curl -X POST http://localhost:3000/api/v1/endpoints \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://httpbin.org/get", "name": "HTTPBin"}'
+
+# Check all registered endpoints
+curl -X POST http://localhost:3000/api/v1/check-all
+
+# View the analytics report
+curl http://localhost:3000/api/v1/report
+
+# Check service status
+curl http://localhost:3000/api/v1/status
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GATEWAY_PORT` | `3000` | Gateway service port |
+| `CHECKER_PORT` | `8080` | Checker service port |
+| `ANALYTICS_PORT` | `5000` | Analytics service port |
+| `CHECKER_URL` | `http://localhost:8080` | Checker service URL |
+| `ANALYTICS_URL` | `http://localhost:5000` | Analytics service URL |
+| `LOG_LEVEL` | `INFO` | Log level (DEBUG, INFO, WARNING, ERROR) |
+
+## Makefile Commands
+
+| Command | Description |
+|---------|-------------|
+| `make test` | Run all tests |
+| `make test-python` | Run Python tests |
+| `make test-go` | Run Go tests |
+| `make test-ts` | Run TypeScript tests |
+| `make lint` | Run all linters |
+| `make up` | Start services with Docker Compose |
+| `make down` | Stop services |
+| `make build` | Build Docker images |
+| `make clean` | Remove containers, images, and volumes |
+
+## CI/CD
+
+GitHub Actions workflow runs on push/PR to `main`:
+1. Python tests + flake8 lint
+2. Go tests + go vet
+3. TypeScript tests + ESLint
+4. Docker Compose build (after all tests pass)
+
+> **Note:** The `.github/workflows/ci.yml` file may need to be added manually after initial repository setup due to GitHub API restrictions on the `.github/` directory.
+
+### CI Workflow Content
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-python:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/analytics
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -r requirements.txt
+      - run: flake8 --max-line-length=120 app.py
+      - run: pytest -v
+
+  test-go:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/checker
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+      - run: go vet ./...
+      - run: go test -v ./...
+
+  test-typescript:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/gateway
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm install
+      - run: npx eslint src/ --ext .ts
+      - run: npm test
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: [test-python, test-go, test-typescript]
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker compose build
+```
+
+## License
+
+MIT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+services:
+  gateway:
+    build: ./services/gateway
+    ports:
+      - "${GATEWAY_PORT:-3000}:3000"
+    environment:
+      - GATEWAY_PORT=3000
+      - CHECKER_URL=http://checker:8080
+      - ANALYTICS_URL=http://analytics:5000
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+    depends_on:
+      checker:
+        condition: service_healthy
+      analytics:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+
+  checker:
+    build: ./services/checker
+    ports:
+      - "${CHECKER_PORT:-8080}:8080"
+    environment:
+      - CHECKER_PORT=8080
+      - ANALYTICS_URL=http://analytics:5000
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+    depends_on:
+      analytics:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+
+  analytics:
+    build: ./services/analytics
+    ports:
+      - "${ANALYTICS_PORT:-5000}:5000"
+    environment:
+      - ANALYTICS_PORT=5000
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5000/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped

--- a/services/analytics/Dockerfile
+++ b/services/analytics/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 5000
+
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "2", "--access-logfile", "-", "app:app"]

--- a/services/analytics/app.py
+++ b/services/analytics/app.py
@@ -1,0 +1,120 @@
+"""PulseWatch Analytics Service - Processes health check data and generates reports."""
+
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from flask import Flask, jsonify, request
+
+app = Flask(__name__)
+
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger("analytics")
+
+PORT = int(os.environ.get("ANALYTICS_PORT", 5000))
+
+# In-memory store for health check results
+health_records: list[dict] = []
+start_time = time.time()
+
+
+@app.route("/health")
+def health():
+    uptime = time.time() - start_time
+    return jsonify({"status": "ok", "service": "analytics", "uptime_seconds": round(uptime, 2)})
+
+
+@app.route("/api/v1/records", methods=["POST"])
+def add_record():
+    data = request.get_json()
+    if not data:
+        logger.warning("Received empty payload for record creation")
+        return jsonify({"error": "Request body is required"}), 400
+
+    endpoint = data.get("endpoint")
+    status_code = data.get("status_code")
+    response_time_ms = data.get("response_time_ms")
+
+    if not endpoint:
+        return jsonify({"error": "Field 'endpoint' is required"}), 400
+    if status_code is None:
+        return jsonify({"error": "Field 'status_code' is required"}), 400
+    if response_time_ms is None:
+        return jsonify({"error": "Field 'response_time_ms' is required"}), 400
+
+    record = {
+        "endpoint": endpoint,
+        "status_code": int(status_code),
+        "response_time_ms": float(response_time_ms),
+        "checked_at": data.get("checked_at", datetime.now(timezone.utc).isoformat()),
+        "healthy": 200 <= int(status_code) < 400,
+    }
+    health_records.append(record)
+    logger.info(
+        "Recorded health check for %s: status=%d, time=%.1fms",
+        endpoint, record["status_code"], record["response_time_ms"]
+    )
+    return jsonify(record), 201
+
+
+@app.route("/api/v1/records", methods=["GET"])
+def list_records():
+    endpoint = request.args.get("endpoint")
+    limit = request.args.get("limit", 100, type=int)
+
+    filtered = health_records
+    if endpoint:
+        filtered = [r for r in filtered if r["endpoint"] == endpoint]
+
+    result = filtered[-limit:]
+    logger.info("Listed %d records (filter=%s, limit=%d)", len(result), endpoint, limit)
+    return jsonify({"records": result, "total": len(filtered)})
+
+
+@app.route("/api/v1/report", methods=["GET"])
+def report():
+    if not health_records:
+        return jsonify({"message": "No records available", "endpoints": {}})
+
+    endpoints: dict[str, dict] = {}
+    for r in health_records:
+        ep = r["endpoint"]
+        if ep not in endpoints:
+            endpoints[ep] = {
+                "total_checks": 0,
+                "healthy_checks": 0,
+                "total_response_time_ms": 0.0,
+                "min_response_time_ms": float("inf"),
+                "max_response_time_ms": 0.0,
+            }
+        stats = endpoints[ep]
+        stats["total_checks"] += 1
+        if r["healthy"]:
+            stats["healthy_checks"] += 1
+        stats["total_response_time_ms"] += r["response_time_ms"]
+        stats["min_response_time_ms"] = min(stats["min_response_time_ms"], r["response_time_ms"])
+        stats["max_response_time_ms"] = max(stats["max_response_time_ms"], r["response_time_ms"])
+
+    report_data: dict[str, dict] = {}
+    for ep, stats in endpoints.items():
+        total = stats["total_checks"]
+        report_data[ep] = {
+            "total_checks": total,
+            "healthy_checks": stats["healthy_checks"],
+            "uptime_percent": round(stats["healthy_checks"] / total * 100, 2) if total > 0 else 0,
+            "avg_response_time_ms": round(stats["total_response_time_ms"] / total, 2) if total > 0 else 0,
+            "min_response_time_ms": round(stats["min_response_time_ms"], 2),
+            "max_response_time_ms": round(stats["max_response_time_ms"], 2),
+        }
+
+    logger.info("Generated report for %d endpoints", len(report_data))
+    return jsonify({"endpoints": report_data})
+
+
+if __name__ == "__main__":
+    logger.info("Starting Analytics Service on port %d", PORT)
+    app.run(host="0.0.0.0", port=PORT)

--- a/services/analytics/requirements.txt
+++ b/services/analytics/requirements.txt
@@ -1,0 +1,4 @@
+flask==3.1.1
+pytest==8.3.4
+flake8==7.1.1
+gunicorn==23.0.0

--- a/services/analytics/test_app.py
+++ b/services/analytics/test_app.py
@@ -1,0 +1,118 @@
+"""Tests for Analytics Service."""
+
+import pytest
+
+from app import app, health_records
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    health_records.clear()
+    with app.test_client() as c:
+        yield c
+
+
+def test_health(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "ok"
+    assert data["service"] == "analytics"
+    assert "uptime_seconds" in data
+
+
+def test_add_record(client):
+    payload = {"endpoint": "https://example.com", "status_code": 200, "response_time_ms": 42.5}
+    resp = client.post("/api/v1/records", json=payload)
+    assert resp.status_code == 201
+    data = resp.get_json()
+    assert data["endpoint"] == "https://example.com"
+    assert data["status_code"] == 200
+    assert data["response_time_ms"] == 42.5
+    assert data["healthy"] is True
+
+
+def test_add_record_unhealthy(client):
+    payload = {"endpoint": "https://down.example.com", "status_code": 503, "response_time_ms": 1200}
+    resp = client.post("/api/v1/records", json=payload)
+    assert resp.status_code == 201
+    data = resp.get_json()
+    assert data["healthy"] is False
+
+
+def test_add_record_missing_endpoint(client):
+    payload = {"status_code": 200, "response_time_ms": 10}
+    resp = client.post("/api/v1/records", json=payload)
+    assert resp.status_code == 400
+
+
+def test_add_record_missing_status_code(client):
+    payload = {"endpoint": "https://example.com", "response_time_ms": 10}
+    resp = client.post("/api/v1/records", json=payload)
+    assert resp.status_code == 400
+
+
+def test_add_record_missing_response_time(client):
+    payload = {"endpoint": "https://example.com", "status_code": 200}
+    resp = client.post("/api/v1/records", json=payload)
+    assert resp.status_code == 400
+
+
+def test_add_record_empty_body(client):
+    resp = client.post("/api/v1/records", content_type="application/json")
+    assert resp.status_code == 400
+
+
+def test_list_records(client):
+    for i in range(3):
+        client.post("/api/v1/records", json={
+            "endpoint": "https://example.com",
+            "status_code": 200,
+            "response_time_ms": 10 + i,
+        })
+    resp = client.get("/api/v1/records")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total"] == 3
+    assert len(data["records"]) == 3
+
+
+def test_list_records_with_filter(client):
+    client.post("/api/v1/records", json={"endpoint": "https://a.com", "status_code": 200, "response_time_ms": 10})
+    client.post("/api/v1/records", json={"endpoint": "https://b.com", "status_code": 200, "response_time_ms": 20})
+    resp = client.get("/api/v1/records?endpoint=https://a.com")
+    data = resp.get_json()
+    assert data["total"] == 1
+    assert data["records"][0]["endpoint"] == "https://a.com"
+
+
+def test_list_records_with_limit(client):
+    for i in range(5):
+        client.post("/api/v1/records", json={"endpoint": "https://x.com", "status_code": 200, "response_time_ms": i})
+    resp = client.get("/api/v1/records?limit=2")
+    data = resp.get_json()
+    assert len(data["records"]) == 2
+
+
+def test_report_empty(client):
+    resp = client.get("/api/v1/report")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["endpoints"] == {}
+
+
+def test_report_with_data(client):
+    client.post("/api/v1/records", json={"endpoint": "https://api.com", "status_code": 200, "response_time_ms": 50})
+    client.post("/api/v1/records", json={"endpoint": "https://api.com", "status_code": 200, "response_time_ms": 100})
+    client.post("/api/v1/records", json={"endpoint": "https://api.com", "status_code": 500, "response_time_ms": 200})
+
+    resp = client.get("/api/v1/report")
+    data = resp.get_json()
+    ep = data["endpoints"]["https://api.com"]
+    assert ep["total_checks"] == 3
+    assert ep["healthy_checks"] == 2
+    assert ep["uptime_percent"] == pytest.approx(66.67, abs=0.01)
+    assert ep["avg_response_time_ms"] == pytest.approx(116.67, abs=0.01)
+    assert ep["min_response_time_ms"] == 50.0
+    assert ep["max_response_time_ms"] == 200.0

--- a/services/checker/Dockerfile
+++ b/services/checker/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.22-alpine AS builder
+
+WORKDIR /app
+COPY go.mod ./
+COPY *.go ./
+RUN go build -o checker .
+
+FROM alpine:3.20
+
+WORKDIR /app
+COPY --from=builder /app/checker .
+
+EXPOSE 8080
+
+CMD ["./checker"]

--- a/services/checker/go.mod
+++ b/services/checker/go.mod
@@ -1,0 +1,3 @@
+module github.com/mohadayo/pulsewatch/services/checker
+
+go 1.22

--- a/services/checker/main.go
+++ b/services/checker/main.go
@@ -1,0 +1,302 @@
+// Package main implements the PulseWatch Checker Service.
+// It performs health checks on registered endpoints and reports results to the Analytics service.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+)
+
+var (
+	port         string
+	analyticsURL string
+	logger       *log.Logger
+	startTime    time.Time
+
+	mu        sync.RWMutex
+	endpoints []Endpoint
+)
+
+// Endpoint represents a monitored URL.
+type Endpoint struct {
+	URL  string `json:"url"`
+	Name string `json:"name"`
+}
+
+// HealthResponse is returned by /health.
+type HealthResponse struct {
+	Status        string  `json:"status"`
+	Service       string  `json:"service"`
+	UptimeSeconds float64 `json:"uptime_seconds"`
+}
+
+// CheckResult is the result of a health check.
+type CheckResult struct {
+	Endpoint       string  `json:"endpoint"`
+	StatusCode     int     `json:"status_code"`
+	ResponseTimeMs float64 `json:"response_time_ms"`
+	CheckedAt      string  `json:"checked_at"`
+	Error          string  `json:"error,omitempty"`
+}
+
+func init() {
+	logger = log.New(os.Stdout, "[checker] ", log.LstdFlags|log.Lmsgprefix)
+	port = getEnv("CHECKER_PORT", "8080")
+	analyticsURL = getEnv("ANALYTICS_URL", "http://localhost:5000")
+	startTime = time.Now()
+}
+
+func getEnv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	uptime := time.Since(startTime).Seconds()
+	resp := HealthResponse{
+		Status:        "ok",
+		Service:       "checker",
+		UptimeSeconds: uptime,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+func listEndpointsHandler(w http.ResponseWriter, r *http.Request) {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"endpoints": endpoints,
+		"total":     len(endpoints),
+	})
+}
+
+func addEndpointHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	var ep Endpoint
+	if err := json.NewDecoder(r.Body).Decode(&ep); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "invalid JSON body"})
+		return
+	}
+
+	if ep.URL == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "field 'url' is required"})
+		return
+	}
+	if ep.Name == "" {
+		ep.Name = ep.URL
+	}
+
+	mu.Lock()
+	endpoints = append(endpoints, ep)
+	mu.Unlock()
+
+	logger.Printf("Registered endpoint: %s (%s)", ep.Name, ep.URL)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(ep)
+}
+
+// CheckEndpoint performs a health check on a single URL.
+func CheckEndpoint(url string) CheckResult {
+	start := time.Now()
+	result := CheckResult{
+		Endpoint:  url,
+		CheckedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
+	elapsed := time.Since(start).Seconds() * 1000
+
+	result.ResponseTimeMs = elapsed
+
+	if err != nil {
+		result.StatusCode = 0
+		result.Error = err.Error()
+		logger.Printf("Check FAILED for %s: %v (%.1fms)", url, err, elapsed)
+		return result
+	}
+	defer resp.Body.Close()
+
+	result.StatusCode = resp.StatusCode
+	logger.Printf("Check OK for %s: status=%d (%.1fms)", url, resp.StatusCode, elapsed)
+	return result
+}
+
+func checkAllHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	mu.RLock()
+	eps := make([]Endpoint, len(endpoints))
+	copy(eps, endpoints)
+	mu.RUnlock()
+
+	if len(eps) == 0 {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"message": "no endpoints registered",
+			"results": []CheckResult{},
+		})
+		return
+	}
+
+	results := make([]CheckResult, len(eps))
+	var wg sync.WaitGroup
+	for i, ep := range eps {
+		wg.Add(1)
+		go func(idx int, url string) {
+			defer wg.Done()
+			results[idx] = CheckEndpoint(url)
+		}(i, ep.URL)
+	}
+	wg.Wait()
+
+	// Report results to analytics service
+	reported := 0
+	for _, result := range results {
+		if reportToAnalytics(result) {
+			reported++
+		}
+	}
+	logger.Printf("Checked %d endpoints, reported %d to analytics", len(results), reported)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"results":  results,
+		"total":    len(results),
+		"reported": reported,
+	})
+}
+
+func reportToAnalytics(result CheckResult) bool {
+	payload := map[string]interface{}{
+		"endpoint":         result.Endpoint,
+		"status_code":      result.StatusCode,
+		"response_time_ms": result.ResponseTimeMs,
+		"checked_at":       result.CheckedAt,
+	}
+	body, _ := json.Marshal(payload)
+
+	resp, err := http.Post(analyticsURL+"/api/v1/records", "application/json", bytes.NewReader(body))
+	if err != nil {
+		logger.Printf("Failed to report to analytics: %v", err)
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == 201
+}
+
+func checkSingleHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	var body struct {
+		URL string `json:"url"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.URL == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "field 'url' is required"})
+		return
+	}
+
+	result := CheckEndpoint(body.URL)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", healthHandler)
+	mux.HandleFunc("/api/v1/endpoints", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			listEndpointsHandler(w, r)
+		case http.MethodPost:
+			addEndpointHandler(w, r)
+		default:
+			http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		}
+	})
+	mux.HandleFunc("/api/v1/check", checkSingleHandler)
+	mux.HandleFunc("/api/v1/check-all", checkAllHandler)
+
+	addr := ":" + port
+	logger.Printf("Starting Checker Service on %s", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		logger.Fatalf("Server failed: %v", err)
+	}
+}
+
+// GetEndpoints returns a copy of registered endpoints (for testing).
+func GetEndpoints() []Endpoint {
+	mu.RLock()
+	defer mu.RUnlock()
+	result := make([]Endpoint, len(endpoints))
+	copy(result, endpoints)
+	return result
+}
+
+// ResetEndpoints clears all registered endpoints (for testing).
+func ResetEndpoints() {
+	mu.Lock()
+	endpoints = nil
+	mu.Unlock()
+}
+
+// GetPort returns the configured port.
+func GetPort() string {
+	return port
+}
+
+// SetPort sets the port (for testing).
+func SetPort(p string) {
+	port = p
+}
+
+// GetAnalyticsURL returns the configured analytics URL.
+func GetAnalyticsURL() string {
+	return analyticsURL
+}
+
+// SetAnalyticsURL sets the analytics URL (for testing).
+func SetAnalyticsURL(u string) {
+	analyticsURL = u
+}
+
+// ParsePort converts port string to int safely.
+func ParsePort(p string) (int, error) {
+	return strconv.Atoi(p)
+}
+
+// FormatAddr creates an address string from host and port.
+func FormatAddr(host string, portNum int) string {
+	return fmt.Sprintf("%s:%d", host, portNum)
+}

--- a/services/checker/main_test.go
+++ b/services/checker/main_test.go
@@ -1,0 +1,334 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func setupTestMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", healthHandler)
+	mux.HandleFunc("/api/v1/endpoints", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			listEndpointsHandler(w, r)
+		case http.MethodPost:
+			addEndpointHandler(w, r)
+		default:
+			http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		}
+	})
+	mux.HandleFunc("/api/v1/check", checkSingleHandler)
+	mux.HandleFunc("/api/v1/check-all", checkAllHandler)
+	return mux
+}
+
+func TestHealthEndpoint(t *testing.T) {
+	mux := setupTestMux()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp HealthResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Status != "ok" {
+		t.Errorf("expected status ok, got %s", resp.Status)
+	}
+	if resp.Service != "checker" {
+		t.Errorf("expected service checker, got %s", resp.Service)
+	}
+}
+
+func TestAddEndpoint(t *testing.T) {
+	ResetEndpoints()
+	mux := setupTestMux()
+
+	body := `{"url":"https://example.com","name":"Example"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/endpoints", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", w.Code)
+	}
+
+	var ep Endpoint
+	json.NewDecoder(w.Body).Decode(&ep)
+	if ep.URL != "https://example.com" {
+		t.Errorf("expected url https://example.com, got %s", ep.URL)
+	}
+	if ep.Name != "Example" {
+		t.Errorf("expected name Example, got %s", ep.Name)
+	}
+
+	eps := GetEndpoints()
+	if len(eps) != 1 {
+		t.Errorf("expected 1 endpoint, got %d", len(eps))
+	}
+}
+
+func TestAddEndpointDefaultName(t *testing.T) {
+	ResetEndpoints()
+	mux := setupTestMux()
+
+	body := `{"url":"https://test.com"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/endpoints", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", w.Code)
+	}
+
+	var ep Endpoint
+	json.NewDecoder(w.Body).Decode(&ep)
+	if ep.Name != "https://test.com" {
+		t.Errorf("expected name to default to URL, got %s", ep.Name)
+	}
+}
+
+func TestAddEndpointMissingURL(t *testing.T) {
+	ResetEndpoints()
+	mux := setupTestMux()
+
+	body := `{"name":"no-url"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/endpoints", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestAddEndpointInvalidJSON(t *testing.T) {
+	ResetEndpoints()
+	mux := setupTestMux()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/endpoints", bytes.NewBufferString("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestListEndpoints(t *testing.T) {
+	ResetEndpoints()
+	mux := setupTestMux()
+
+	// Add two endpoints
+	for _, url := range []string{"https://a.com", "https://b.com"} {
+		body := `{"url":"` + url + `"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/endpoints", bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/endpoints", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var result map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&result)
+	total := int(result["total"].(float64))
+	if total != 2 {
+		t.Errorf("expected 2 endpoints, got %d", total)
+	}
+}
+
+func TestCheckSingleMissingURL(t *testing.T) {
+	mux := setupTestMux()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/check", bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCheckSingleWithMockServer(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer mockServer.Close()
+
+	mux := setupTestMux()
+	body := `{"url":"` + mockServer.URL + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/check", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var result CheckResult
+	json.NewDecoder(w.Body).Decode(&result)
+	if result.StatusCode != 200 {
+		t.Errorf("expected status 200, got %d", result.StatusCode)
+	}
+	if result.ResponseTimeMs <= 0 {
+		t.Error("expected positive response time")
+	}
+}
+
+func TestCheckAllNoEndpoints(t *testing.T) {
+	ResetEndpoints()
+	mux := setupTestMux()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/check-all", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var result map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&result)
+	if result["message"] != "no endpoints registered" {
+		t.Errorf("expected no endpoints message, got %v", result["message"])
+	}
+}
+
+func TestCheckAllWithEndpoints(t *testing.T) {
+	ResetEndpoints()
+
+	// Create mock target server
+	mockTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockTarget.Close()
+
+	// Create mock analytics server
+	mockAnalytics := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer mockAnalytics.Close()
+
+	SetAnalyticsURL(mockAnalytics.URL)
+	defer SetAnalyticsURL("http://localhost:5000")
+
+	mux := setupTestMux()
+
+	// Register endpoint
+	body := `{"url":"` + mockTarget.URL + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/endpoints", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	// Check all
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/check-all", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var result map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&result)
+	total := int(result["total"].(float64))
+	if total != 1 {
+		t.Errorf("expected 1 result, got %d", total)
+	}
+	reported := int(result["reported"].(float64))
+	if reported != 1 {
+		t.Errorf("expected 1 reported, got %d", reported)
+	}
+}
+
+func TestCheckEndpointFunction(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	result := CheckEndpoint(mockServer.URL)
+	if result.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", result.StatusCode)
+	}
+	if result.Endpoint != mockServer.URL {
+		t.Errorf("expected endpoint %s, got %s", mockServer.URL, result.Endpoint)
+	}
+}
+
+func TestCheckEndpointUnreachable(t *testing.T) {
+	result := CheckEndpoint("http://localhost:19999")
+	if result.StatusCode != 0 {
+		t.Errorf("expected status 0 for unreachable, got %d", result.StatusCode)
+	}
+	if result.Error == "" {
+		t.Error("expected error message for unreachable endpoint")
+	}
+}
+
+func TestEndpointsMethodNotAllowed(t *testing.T) {
+	mux := setupTestMux()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/endpoints", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestCheckMethodNotAllowed(t *testing.T) {
+	mux := setupTestMux()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/check", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestParsePort(t *testing.T) {
+	p, err := ParsePort("8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p != 8080 {
+		t.Errorf("expected 8080, got %d", p)
+	}
+
+	_, err = ParsePort("abc")
+	if err == nil {
+		t.Error("expected error for non-numeric port")
+	}
+}
+
+func TestFormatAddr(t *testing.T) {
+	addr := FormatAddr("0.0.0.0", 8080)
+	if addr != "0.0.0.0:8080" {
+		t.Errorf("expected 0.0.0.0:8080, got %s", addr)
+	}
+}

--- a/services/gateway/.eslintrc.json
+++ b/services/gateway/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "env": {
+    "node": true,
+    "es2020": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  },
+  "rules": {
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+  }
+}

--- a/services/gateway/Dockerfile
+++ b/services/gateway/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN npm run build
+
+FROM node:20-alpine
+
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --omit=dev
+COPY --from=builder /app/dist ./dist
+
+EXPOSE 3000
+
+CMD ["node", "dist/index.js"]

--- a/services/gateway/jest.config.js
+++ b/services/gateway/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+};

--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "pulsewatch-gateway",
+  "version": "1.0.0",
+  "description": "PulseWatch API Gateway Service",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts",
+    "test": "jest --forceExit",
+    "lint": "eslint src/ --ext .ts"
+  },
+  "dependencies": {
+    "express": "^4.21.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^22.10.0",
+    "@types/supertest": "^6.0.2",
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^7.18.0",
+    "eslint": "^8.57.1",
+    "jest": "^29.7.0",
+    "supertest": "^7.0.0",
+    "ts-jest": "^29.2.5",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/services/gateway/src/app.test.ts
+++ b/services/gateway/src/app.test.ts
@@ -1,0 +1,162 @@
+import request from "supertest";
+import { app } from "./app";
+import http from "http";
+
+describe("Gateway Service", () => {
+  describe("GET /health", () => {
+    it("should return health status", async () => {
+      const res = await request(app).get("/health");
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe("ok");
+      expect(res.body.service).toBe("gateway");
+      expect(res.body.uptime_seconds).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe("POST /api/v1/endpoints", () => {
+    it("should reject missing url", async () => {
+      const res = await request(app)
+        .post("/api/v1/endpoints")
+        .send({ name: "test" });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("url");
+    });
+  });
+
+  describe("POST /api/v1/check", () => {
+    it("should reject missing url", async () => {
+      const res = await request(app)
+        .post("/api/v1/check")
+        .send({});
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("url");
+    });
+  });
+
+  describe("GET /api/v1/status", () => {
+    it("should return degraded when services are down", async () => {
+      const res = await request(app).get("/api/v1/status");
+      expect(res.status).toBe(200);
+      expect(res.body.overall).toBe("degraded");
+      expect(res.body.services).toBeDefined();
+      expect(res.body.services.checker.healthy).toBe(false);
+      expect(res.body.services.analytics.healthy).toBe(false);
+    });
+  });
+
+  describe("proxy to checker service", () => {
+    let mockChecker: http.Server;
+    const originalEnv = process.env.CHECKER_URL;
+
+    beforeAll((done) => {
+      mockChecker = http
+        .createServer((req, res) => {
+          res.setHeader("Content-Type", "application/json");
+
+          if (req.method === "GET" && req.url === "/api/v1/endpoints") {
+            res.writeHead(200);
+            res.end(JSON.stringify({ endpoints: [], total: 0 }));
+          } else if (req.method === "POST" && req.url === "/api/v1/endpoints") {
+            let body = "";
+            req.on("data", (chunk) => (body += chunk));
+            req.on("end", () => {
+              const data = JSON.parse(body);
+              res.writeHead(201);
+              res.end(JSON.stringify(data));
+            });
+          } else if (req.method === "POST" && req.url === "/api/v1/check-all") {
+            res.writeHead(200);
+            res.end(JSON.stringify({ results: [], total: 0, reported: 0 }));
+          } else if (req.url === "/health") {
+            res.writeHead(200);
+            res.end(JSON.stringify({ status: "ok", service: "checker" }));
+          } else {
+            res.writeHead(404);
+            res.end(JSON.stringify({ error: "not found" }));
+          }
+        })
+        .listen(0, () => {
+          const addr = mockChecker.address();
+          if (addr && typeof addr !== "string") {
+            process.env.CHECKER_URL = `http://127.0.0.1:${addr.port}`;
+          }
+          done();
+        });
+    });
+
+    afterAll((done) => {
+      process.env.CHECKER_URL = originalEnv;
+      mockChecker.close(done);
+    });
+
+    it("should proxy GET /api/v1/endpoints", async () => {
+      const res = await request(app).get("/api/v1/endpoints");
+      expect(res.status).toBe(200);
+      expect(res.body.endpoints).toEqual([]);
+    });
+
+    it("should proxy POST /api/v1/endpoints", async () => {
+      const res = await request(app)
+        .post("/api/v1/endpoints")
+        .send({ url: "https://example.com", name: "Example" });
+      expect(res.status).toBe(201);
+      expect(res.body.url).toBe("https://example.com");
+    });
+
+    it("should proxy POST /api/v1/check-all", async () => {
+      const res = await request(app).post("/api/v1/check-all");
+      expect(res.status).toBe(200);
+      expect(res.body.results).toEqual([]);
+    });
+  });
+
+  describe("proxy to analytics service", () => {
+    let mockAnalytics: http.Server;
+    const originalEnv = process.env.ANALYTICS_URL;
+
+    beforeAll((done) => {
+      mockAnalytics = http
+        .createServer((req, res) => {
+          res.setHeader("Content-Type", "application/json");
+
+          if (req.method === "GET" && req.url?.startsWith("/api/v1/records")) {
+            res.writeHead(200);
+            res.end(JSON.stringify({ records: [], total: 0 }));
+          } else if (req.method === "GET" && req.url === "/api/v1/report") {
+            res.writeHead(200);
+            res.end(JSON.stringify({ endpoints: {} }));
+          } else if (req.url === "/health") {
+            res.writeHead(200);
+            res.end(JSON.stringify({ status: "ok", service: "analytics" }));
+          } else {
+            res.writeHead(404);
+            res.end(JSON.stringify({ error: "not found" }));
+          }
+        })
+        .listen(0, () => {
+          const addr = mockAnalytics.address();
+          if (addr && typeof addr !== "string") {
+            process.env.ANALYTICS_URL = `http://127.0.0.1:${addr.port}`;
+          }
+          done();
+        });
+    });
+
+    afterAll((done) => {
+      process.env.ANALYTICS_URL = originalEnv;
+      mockAnalytics.close(done);
+    });
+
+    it("should proxy GET /api/v1/records", async () => {
+      const res = await request(app).get("/api/v1/records");
+      expect(res.status).toBe(200);
+      expect(res.body.records).toEqual([]);
+    });
+
+    it("should proxy GET /api/v1/report", async () => {
+      const res = await request(app).get("/api/v1/report");
+      expect(res.status).toBe(200);
+      expect(res.body.endpoints).toEqual({});
+    });
+  });
+});

--- a/services/gateway/src/app.ts
+++ b/services/gateway/src/app.ts
@@ -1,0 +1,149 @@
+import express, { Request, Response, NextFunction } from "express";
+
+const app = express();
+app.use(express.json());
+
+function checkerUrl(): string {
+  return process.env.CHECKER_URL || "http://localhost:8080";
+}
+function analyticsUrl(): string {
+  return process.env.ANALYTICS_URL || "http://localhost:5000";
+}
+const startTime = Date.now();
+
+const logger = {
+  info: (msg: string, ...args: unknown[]) =>
+    console.log(`${new Date().toISOString()} [INFO] gateway: ${msg}`, ...args),
+  warn: (msg: string, ...args: unknown[]) =>
+    console.warn(`${new Date().toISOString()} [WARN] gateway: ${msg}`, ...args),
+  error: (msg: string, ...args: unknown[]) =>
+    console.error(`${new Date().toISOString()} [ERROR] gateway: ${msg}`, ...args),
+};
+
+async function proxyRequest(
+  baseUrl: string,
+  path: string,
+  method: string,
+  body?: unknown
+): Promise<{ status: number; data: unknown }> {
+  const url = `${baseUrl}${path}`;
+  const options: RequestInit = {
+    method,
+    headers: { "Content-Type": "application/json" },
+  };
+  if (body && method !== "GET") {
+    options.body = JSON.stringify(body);
+  }
+
+  const response = await fetch(url, options);
+  const data = await response.json();
+  return { status: response.status, data };
+}
+
+// Health check
+app.get("/health", (_req: Request, res: Response) => {
+  const uptimeSeconds = (Date.now() - startTime) / 1000;
+  res.json({ status: "ok", service: "gateway", uptime_seconds: Number(uptimeSeconds.toFixed(2)) });
+});
+
+// Service status - aggregate health from all services
+app.get("/api/v1/status", async (_req: Request, res: Response) => {
+  const services: Record<string, unknown> = {};
+
+  try {
+    const checker = await proxyRequest(checkerUrl(), "/health", "GET");
+    services.checker = { healthy: true, ...checker.data as object };
+  } catch {
+    services.checker = { healthy: false, error: "unreachable" };
+  }
+
+  try {
+    const analytics = await proxyRequest(analyticsUrl(), "/health", "GET");
+    services.analytics = { healthy: true, ...analytics.data as object };
+  } catch {
+    services.analytics = { healthy: false, error: "unreachable" };
+  }
+
+  const allHealthy = Object.values(services).every(
+    (s) => (s as Record<string, unknown>).healthy === true
+  );
+
+  logger.info(`Status check: all_healthy=${allHealthy}`);
+  res.json({ overall: allHealthy ? "healthy" : "degraded", services });
+});
+
+// Endpoints CRUD - proxy to checker
+app.get("/api/v1/endpoints", async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await proxyRequest(checkerUrl(), "/api/v1/endpoints", "GET");
+    res.status(result.status).json(result.data);
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.post("/api/v1/endpoints", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    if (!req.body.url) {
+      res.status(400).json({ error: "Field 'url' is required" });
+      return;
+    }
+    const result = await proxyRequest(checkerUrl(), "/api/v1/endpoints", "POST", req.body);
+    logger.info(`Registered endpoint: ${req.body.url}`);
+    res.status(result.status).json(result.data);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Health check operations - proxy to checker
+app.post("/api/v1/check", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    if (!req.body.url) {
+      res.status(400).json({ error: "Field 'url' is required" });
+      return;
+    }
+    const result = await proxyRequest(checkerUrl(), "/api/v1/check", "POST", req.body);
+    res.status(result.status).json(result.data);
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.post("/api/v1/check-all", async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await proxyRequest(checkerUrl(), "/api/v1/check-all", "POST");
+    res.status(result.status).json(result.data);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Analytics - proxy to analytics service
+app.get("/api/v1/records", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const query = req.url.split("?")[1] || "";
+    const path = query ? `/api/v1/records?${query}` : "/api/v1/records";
+    const result = await proxyRequest(analyticsUrl(), path, "GET");
+    res.status(result.status).json(result.data);
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.get("/api/v1/report", async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await proxyRequest(analyticsUrl(), "/api/v1/report", "GET");
+    res.status(result.status).json(result.data);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Error handler
+app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+  logger.error(`Unhandled error: ${err.message}`);
+  res.status(502).json({ error: "Service unavailable", message: err.message });
+});
+
+export { app, proxyRequest };

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -1,0 +1,9 @@
+import { app } from "./app";
+
+const PORT = parseInt(process.env.GATEWAY_PORT || "3000", 10);
+
+app.listen(PORT, "0.0.0.0", () => {
+  console.log(
+    `${new Date().toISOString()} [INFO] gateway: Starting Gateway Service on port ${PORT}`
+  );
+});

--- a/services/gateway/tsconfig.json
+++ b/services/gateway/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

- **Gateway Service** (TypeScript/Express, port 3000): API gateway that routes requests to backend services, aggregates health status, and validates input
- **Checker Service** (Go/net/http, port 8080): Performs concurrent health checks on registered endpoints and reports results to Analytics
- **Analytics Service** (Python/Flask, port 5000): Stores health check records and generates uptime/performance reports

## What's Included

- Full Docker Compose setup with health checks and service dependencies
- Makefile with `test`, `lint`, `up`, `down`, `build`, `clean` targets
- `.gitignore` covering Python, Go, TypeScript, Docker, IDE files
- `.env.example` with all configurable environment variables
- Comprehensive README with architecture diagram (Mermaid), API reference, and setup instructions

## Test Results

### Python (Analytics Service) - 12/12 passed
- Health endpoint, record CRUD, filtering, pagination, report generation, error handling

### Go (Checker Service) - 16/16 passed
- Health endpoint, endpoint registration, single/batch health checks, mock server tests, error cases

### TypeScript (Gateway Service) - 9/9 passed
- Health endpoint, input validation, proxy to checker, proxy to analytics, status aggregation

### Linting
- Python: flake8 (max-line-length=120) - clean
- Go: go vet - clean
- TypeScript: ESLint - clean

## Startup

```bash
cp .env.example .env
docker compose up --build -d
# or
make up
```

## Note on CI

The `.github/workflows/ci.yml` file could not be uploaded via the GitHub API due to OAuth App restrictions on the `.github/` directory. The workflow content is included in the README and should be added manually after merge.