### PR TITLE
Checker/Gateway: エンドポイント削除機能の追加

### DIFF
--- a/services/checker/main.go
+++ b/services/checker/main.go
@@ -117,6 +117,45 @@ func addEndpointHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(ep)
 }
 
+func deleteEndpointHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	var body struct {
+		URL string `json:"url"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.URL == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "field 'url' is required"})
+		return
+	}
+
+	mu.Lock()
+	found := false
+	for i, ep := range endpoints {
+		if ep.URL == body.URL {
+			endpoints = append(endpoints[:i], endpoints[i+1:]...)
+			found = true
+			logger.Printf("Removed endpoint: %s (%s)", ep.Name, ep.URL)
+			break
+		}
+	}
+	mu.Unlock()
+
+	if !found {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "endpoint not found"})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"message": "endpoint removed"})
+}
+
 // CheckEndpoint performs a health check on a single URL.
 func CheckEndpoint(url string) CheckResult {
 	start := time.Now()
@@ -241,6 +280,8 @@ func main() {
 			listEndpointsHandler(w, r)
 		case http.MethodPost:
 			addEndpointHandler(w, r)
+		case http.MethodDelete:
+			deleteEndpointHandler(w, r)
 		default:
 			http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
 		}

--- a/services/checker/main_test.go
+++ b/services/checker/main_test.go
@@ -17,6 +17,8 @@ func setupTestMux() *http.ServeMux {
 			listEndpointsHandler(w, r)
 		case http.MethodPost:
 			addEndpointHandler(w, r)
+		case http.MethodDelete:
+			deleteEndpointHandler(w, r)
 		default:
 			http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
 		}
@@ -156,6 +158,107 @@ func TestListEndpoints(t *testing.T) {
 	}
 }
 
+func TestDeleteEndpoint(t *testing.T) {
+	ResetEndpoints()
+	mux := setupTestMux()
+
+	// Add an endpoint
+	addBody := `{"url":"https://delete-me.com","name":"DeleteMe"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/endpoints", bytes.NewBufferString(addBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 on add, got %d", w.Code)
+	}
+
+	// Delete it
+	delBody := `{"url":"https://delete-me.com"}`
+	req = httptest.NewRequest(http.MethodDelete, "/api/v1/endpoints", bytes.NewBufferString(delBody))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 on delete, got %d", w.Code)
+	}
+
+	var result map[string]string
+	json.NewDecoder(w.Body).Decode(&result)
+	if result["message"] != "endpoint removed" {
+		t.Errorf("expected 'endpoint removed', got %s", result["message"])
+	}
+
+	eps := GetEndpoints()
+	if len(eps) != 0 {
+		t.Errorf("expected 0 endpoints after delete, got %d", len(eps))
+	}
+}
+
+func TestDeleteEndpointNotFound(t *testing.T) {
+	ResetEndpoints()
+	mux := setupTestMux()
+
+	body := `{"url":"https://nonexistent.com"}`
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/endpoints", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestDeleteEndpointMissingURL(t *testing.T) {
+	ResetEndpoints()
+	mux := setupTestMux()
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/endpoints", bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestDeleteEndpointPreservesOthers(t *testing.T) {
+	ResetEndpoints()
+	mux := setupTestMux()
+
+	// Add three endpoints
+	for _, url := range []string{"https://a.com", "https://b.com", "https://c.com"} {
+		body := `{"url":"` + url + `"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/endpoints", bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+	}
+
+	// Delete the middle one
+	delBody := `{"url":"https://b.com"}`
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/endpoints", bytes.NewBufferString(delBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	eps := GetEndpoints()
+	if len(eps) != 2 {
+		t.Fatalf("expected 2 endpoints, got %d", len(eps))
+	}
+	for _, ep := range eps {
+		if ep.URL == "https://b.com" {
+			t.Error("deleted endpoint should not be present")
+		}
+	}
+}
+
 func TestCheckSingleMissingURL(t *testing.T) {
 	mux := setupTestMux()
 
@@ -291,7 +394,7 @@ func TestCheckEndpointUnreachable(t *testing.T) {
 
 func TestEndpointsMethodNotAllowed(t *testing.T) {
 	mux := setupTestMux()
-	req := httptest.NewRequest(http.MethodDelete, "/api/v1/endpoints", nil)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/endpoints", nil)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 

--- a/services/gateway/src/app.test.ts
+++ b/services/gateway/src/app.test.ts
@@ -23,6 +23,16 @@ describe("Gateway Service", () => {
     });
   });
 
+  describe("DELETE /api/v1/endpoints", () => {
+    it("should reject missing url", async () => {
+      const res = await request(app)
+        .delete("/api/v1/endpoints")
+        .send({});
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("url");
+    });
+  });
+
   describe("POST /api/v1/check", () => {
     it("should reject missing url", async () => {
       const res = await request(app)
@@ -64,6 +74,19 @@ describe("Gateway Service", () => {
               res.writeHead(201);
               res.end(JSON.stringify(data));
             });
+          } else if (req.method === "DELETE" && req.url === "/api/v1/endpoints") {
+            let body = "";
+            req.on("data", (chunk) => (body += chunk));
+            req.on("end", () => {
+              const data = JSON.parse(body);
+              if (data.url === "https://exists.com") {
+                res.writeHead(200);
+                res.end(JSON.stringify({ message: "endpoint removed" }));
+              } else {
+                res.writeHead(404);
+                res.end(JSON.stringify({ error: "endpoint not found" }));
+              }
+            });
           } else if (req.method === "POST" && req.url === "/api/v1/check-all") {
             res.writeHead(200);
             res.end(JSON.stringify({ results: [], total: 0, reported: 0 }));
@@ -101,6 +124,22 @@ describe("Gateway Service", () => {
         .send({ url: "https://example.com", name: "Example" });
       expect(res.status).toBe(201);
       expect(res.body.url).toBe("https://example.com");
+    });
+
+    it("should proxy DELETE /api/v1/endpoints (success)", async () => {
+      const res = await request(app)
+        .delete("/api/v1/endpoints")
+        .send({ url: "https://exists.com" });
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe("endpoint removed");
+    });
+
+    it("should proxy DELETE /api/v1/endpoints (not found)", async () => {
+      const res = await request(app)
+        .delete("/api/v1/endpoints")
+        .send({ url: "https://nonexistent.com" });
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe("endpoint not found");
     });
 
     it("should proxy POST /api/v1/check-all", async () => {

--- a/services/gateway/src/app.ts
+++ b/services/gateway/src/app.ts
@@ -96,6 +96,20 @@ app.post("/api/v1/endpoints", async (req: Request, res: Response, next: NextFunc
   }
 });
 
+app.delete("/api/v1/endpoints", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    if (!req.body.url) {
+      res.status(400).json({ error: "Field 'url' is required" });
+      return;
+    }
+    const result = await proxyRequest(checkerUrl(), "/api/v1/endpoints", "DELETE", req.body);
+    logger.info(`Removed endpoint: ${req.body.url}`);
+    res.status(result.status).json(result.data);
+  } catch (err) {
+    next(err);
+  }
+});
+
 // Health check operations - proxy to checker
 app.post("/api/v1/check", async (req: Request, res: Response, next: NextFunction) => {
   try {


### PR DESCRIPTION
## 変更概要

- **Checker Service (Go)**:
  - `DELETE /api/v1/endpoints` エンドポイントを追加
  - URLをボディで指定して監視対象から削除
  - 存在しないURLは404を返却
  - テスト4件追加（削除成功・不存在・URL未指定・他エンドポイント保持確認）

- **Gateway Service (TypeScript)**:
  - `DELETE /api/v1/endpoints` プロキシルートを追加
  - URL未指定時のバリデーション
  - テスト3件追加（バリデーション・成功・不存在のプロキシ確認）

Closes #2

## 動作確認手順

```bash
# Checker テスト
cd services/checker && go test -v ./...

# Gateway テスト
cd services/gateway && npm install && npm test
```