### PR TITLE
fix: analytics サービスの入力バリデーション強化

### DIFF
--- a/services/analytics/app.py
+++ b/services/analytics/app.py
@@ -46,12 +46,25 @@ def add_record():
     if response_time_ms is None:
         return jsonify({"error": "Field 'response_time_ms' is required"}), 400
 
+    try:
+        status_code = int(status_code)
+    except (ValueError, TypeError):
+        return jsonify({"error": "Field 'status_code' must be an integer"}), 400
+
+    try:
+        response_time_ms = float(response_time_ms)
+    except (ValueError, TypeError):
+        return jsonify({"error": "Field 'response_time_ms' must be a number"}), 400
+
+    if response_time_ms < 0:
+        return jsonify({"error": "Field 'response_time_ms' must be non-negative"}), 400
+
     record = {
         "endpoint": endpoint,
-        "status_code": int(status_code),
-        "response_time_ms": float(response_time_ms),
+        "status_code": status_code,
+        "response_time_ms": response_time_ms,
         "checked_at": data.get("checked_at", datetime.now(timezone.utc).isoformat()),
-        "healthy": 200 <= int(status_code) < 400,
+        "healthy": 200 <= status_code < 400,
     }
     health_records.append(record)
     logger.info(

--- a/services/analytics/test_app.py
+++ b/services/analytics/test_app.py
@@ -64,6 +64,36 @@ def test_add_record_empty_body(client):
     assert resp.status_code == 400
 
 
+def test_add_record_negative_response_time(client):
+    payload = {"endpoint": "https://example.com", "status_code": 200, "response_time_ms": -5.0}
+    resp = client.post("/api/v1/records", json=payload)
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "non-negative" in data["error"]
+
+
+def test_add_record_zero_response_time(client):
+    payload = {"endpoint": "https://example.com", "status_code": 200, "response_time_ms": 0}
+    resp = client.post("/api/v1/records", json=payload)
+    assert resp.status_code == 201
+
+
+def test_add_record_invalid_status_code(client):
+    payload = {"endpoint": "https://example.com", "status_code": "abc", "response_time_ms": 10}
+    resp = client.post("/api/v1/records", json=payload)
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "integer" in data["error"]
+
+
+def test_add_record_invalid_response_time(client):
+    payload = {"endpoint": "https://example.com", "status_code": 200, "response_time_ms": "fast"}
+    resp = client.post("/api/v1/records", json=payload)
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "number" in data["error"]
+
+
 def test_list_records(client):
     for i in range(3):
         client.post("/api/v1/records", json={


### PR DESCRIPTION
## 変更概要
- `response_time_ms` が負の値の場合に 400 エラーを返すバリデーションを追加
- `status_code` が整数変換不可の値の場合に 400 エラーを返すバリデーションを追加
- `response_time_ms` が数値変換不可の値の場合に 400 エラーを返すバリデーションを追加
- 既存テストは全て維持しつつ、新規テスト 4 件を追加

## テスト
- `test_add_record_negative_response_time`: 負値で 400 確認
- `test_add_record_zero_response_time`: 0 は許可
- `test_add_record_invalid_status_code`: 文字列 status_code で 400
- `test_add_record_invalid_response_time`: 文字列 response_time で 400

## 動作確認手順
```bash
cd services/analytics && pip install -r requirements.txt && pytest -v
```

Closes #4