### PR TITLE
fix: gateway のプロキシリクエストにタイムアウトを追加

### DIFF
--- a/services/gateway/src/app.test.ts
+++ b/services/gateway/src/app.test.ts
@@ -198,4 +198,41 @@ describe("Gateway Service", () => {
       expect(res.body.endpoints).toEqual({});
     });
   });
+
+  describe("proxy timeout", () => {
+    let slowServer: http.Server;
+    const originalEnv = process.env.CHECKER_URL;
+    const originalTimeout = process.env.PROXY_TIMEOUT_MS;
+
+    beforeAll((done) => {
+      process.env.PROXY_TIMEOUT_MS = "200";
+      slowServer = http
+        .createServer((_req, res) => {
+          setTimeout(() => {
+            res.setHeader("Content-Type", "application/json");
+            res.writeHead(200);
+            res.end(JSON.stringify({ endpoints: [], total: 0 }));
+          }, 2000);
+        })
+        .listen(0, () => {
+          const addr = slowServer.address();
+          if (addr && typeof addr !== "string") {
+            process.env.CHECKER_URL = `http://127.0.0.1:${addr.port}`;
+          }
+          done();
+        });
+    });
+
+    afterAll((done) => {
+      process.env.CHECKER_URL = originalEnv;
+      process.env.PROXY_TIMEOUT_MS = originalTimeout;
+      slowServer.close(done);
+    });
+
+    it("should return 504 when upstream times out", async () => {
+      const res = await request(app).get("/api/v1/endpoints");
+      expect(res.status).toBe(504);
+      expect(res.body.error).toBe("Gateway timeout");
+    }, 10000);
+  });
 });

--- a/services/gateway/src/app.ts
+++ b/services/gateway/src/app.ts
@@ -9,6 +9,9 @@ function checkerUrl(): string {
 function analyticsUrl(): string {
   return process.env.ANALYTICS_URL || "http://localhost:5000";
 }
+function proxyTimeoutMs(): number {
+  return parseInt(process.env.PROXY_TIMEOUT_MS || "10000", 10);
+}
 const startTime = Date.now();
 
 const logger = {
@@ -27,17 +30,25 @@ async function proxyRequest(
   body?: unknown
 ): Promise<{ status: number; data: unknown }> {
   const url = `${baseUrl}${path}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), proxyTimeoutMs());
+
   const options: RequestInit = {
     method,
     headers: { "Content-Type": "application/json" },
+    signal: controller.signal,
   };
   if (body && method !== "GET") {
     options.body = JSON.stringify(body);
   }
 
-  const response = await fetch(url, options);
-  const data = await response.json();
-  return { status: response.status, data };
+  try {
+    const response = await fetch(url, options);
+    const data = await response.json();
+    return { status: response.status, data };
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 // Health check
@@ -156,6 +167,11 @@ app.get("/api/v1/report", async (_req: Request, res: Response, next: NextFunctio
 
 // Error handler
 app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+  if (err.name === "AbortError") {
+    logger.error(`Proxy timeout: ${err.message}`);
+    res.status(504).json({ error: "Gateway timeout", message: "Upstream service did not respond in time" });
+    return;
+  }
   logger.error(`Unhandled error: ${err.message}`);
   res.status(502).json({ error: "Service unavailable", message: err.message });
 });


### PR DESCRIPTION
## 変更概要

- `proxyRequest` 関数に `AbortController` によるタイムアウト制御を追加
- `PROXY_TIMEOUT_MS` 環境変数（デフォルト 10000ms）で設定可能
- タイムアウト時は 504 Gateway Timeout を返却（502 Service Unavailable と区別）
- タイ���アウト動作を検証するテストを追加（合計13テスト全パス）

Closes #6

## 動作確認
- `eslint`: パス
- `jest --forceExit`: 13テスト全パス