### PR TITLE
fix: checker の reportToAnalytics にタイムアウトを追加

### DIFF
--- a/services/checker/main.go
+++ b/services/checker/main.go
@@ -22,6 +22,8 @@ var (
 
 	mu        sync.RWMutex
 	endpoints []Endpoint
+
+	reportTimeout = 5 * time.Second
 )
 
 // Endpoint represents a monitored URL.
@@ -240,7 +242,8 @@ func reportToAnalytics(result CheckResult) bool {
 	}
 	body, _ := json.Marshal(payload)
 
-	resp, err := http.Post(analyticsURL+"/api/v1/records", "application/json", bytes.NewReader(body))
+	client := &http.Client{Timeout: reportTimeout}
+	resp, err := client.Post(analyticsURL+"/api/v1/records", "application/json", bytes.NewReader(body))
 	if err != nil {
 		logger.Printf("Failed to report to analytics: %v", err)
 		return false
@@ -330,6 +333,11 @@ func GetAnalyticsURL() string {
 // SetAnalyticsURL sets the analytics URL (for testing).
 func SetAnalyticsURL(u string) {
 	analyticsURL = u
+}
+
+// SetReportTimeout sets the report timeout (for testing).
+func SetReportTimeout(d time.Duration) {
+	reportTimeout = d
 }
 
 // ParsePort converts port string to int safely.

--- a/services/checker/main_test.go
+++ b/services/checker/main_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func setupTestMux() *http.ServeMux {
@@ -433,5 +434,66 @@ func TestFormatAddr(t *testing.T) {
 	addr := FormatAddr("0.0.0.0", 8080)
 	if addr != "0.0.0.0:8080" {
 		t.Errorf("expected 0.0.0.0:8080, got %s", addr)
+	}
+}
+
+func TestReportToAnalyticsSuccess(t *testing.T) {
+	mockAnalytics := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/records" {
+			t.Errorf("expected path /api/v1/records, got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer mockAnalytics.Close()
+
+	oldURL := GetAnalyticsURL()
+	SetAnalyticsURL(mockAnalytics.URL)
+	defer SetAnalyticsURL(oldURL)
+
+	result := CheckResult{
+		Endpoint:       "https://example.com",
+		StatusCode:     200,
+		ResponseTimeMs: 42.5,
+		CheckedAt:      "2026-01-01T00:00:00Z",
+	}
+	if !reportToAnalytics(result) {
+		t.Error("expected reportToAnalytics to return true")
+	}
+}
+
+func TestReportToAnalyticsUnreachable(t *testing.T) {
+	oldURL := GetAnalyticsURL()
+	SetAnalyticsURL("http://localhost:19999")
+	defer SetAnalyticsURL(oldURL)
+
+	result := CheckResult{
+		Endpoint:   "https://example.com",
+		StatusCode: 200,
+	}
+	if reportToAnalytics(result) {
+		t.Error("expected reportToAnalytics to return false for unreachable server")
+	}
+}
+
+func TestReportToAnalyticsTimeout(t *testing.T) {
+	slowServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer slowServer.Close()
+
+	oldURL := GetAnalyticsURL()
+	SetAnalyticsURL(slowServer.URL)
+	defer SetAnalyticsURL(oldURL)
+
+	SetReportTimeout(50 * time.Millisecond)
+	defer SetReportTimeout(5 * time.Second)
+
+	result := CheckResult{
+		Endpoint:   "https://example.com",
+		StatusCode: 200,
+	}
+	if reportToAnalytics(result) {
+		t.Error("expected reportToAnalytics to return false due to timeout")
 	}
 }


### PR DESCRIPTION
## 変更概要

- `reportToAnalytics` 関数でデフォルトの `http.Post()` をタイムアウト付き `http.Client` に変更（デフォルト5秒）
- テスト用に `SetReportTimeout` ヘルパーを追加
- 新規テスト3件を追加:
  - `TestReportToAnalyticsSuccess` — 正常レポート
  - `TestReportToAnalyticsUnreachable` — 到達不能時の処理
  - `TestReportToAnalyticsTimeout` — タイムアウト時の処理

Closes #10

## 動作確認手順

1. `cd services/checker && go test -v ./...` を実行し全テストが通ることを確認
2. `go vet ./...` でエラーがないことを確認