### PR TITLE
feat: checkerのURLバリデーション・重複防止とテスト依存分離

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ test: test-python test-go test-ts
 
 ## Run Python tests
 test-python:
-	cd services/analytics && pip install -q -r requirements.txt && pytest -v
+	cd services/analytics && pip install -q -r requirements-dev.txt && pytest -v
 
 ## Run Go tests
 test-go:
@@ -20,7 +20,7 @@ lint: lint-python lint-go lint-ts
 
 ## Lint Python
 lint-python:
-	cd services/analytics && pip install -q -r requirements.txt && flake8 --max-line-length=120 app.py
+	cd services/analytics && pip install -q -r requirements-dev.txt && flake8 --max-line-length=120 app.py
 
 ## Lint Go
 lint-go:

--- a/services/analytics/requirements-dev.txt
+++ b/services/analytics/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==8.3.4
+flake8==7.1.1

--- a/services/analytics/requirements.txt
+++ b/services/analytics/requirements.txt
@@ -1,4 +1,2 @@
 flask==3.1.1
-pytest==8.3.4
-flake8==7.1.1
 gunicorn==23.0.0

--- a/services/checker/main.go
+++ b/services/checker/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"sync"
@@ -104,11 +105,29 @@ func addEndpointHandler(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]string{"error": "field 'url' is required"})
 		return
 	}
+
+	parsed, err := url.ParseRequestURI(ep.URL)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "field 'url' must be a valid HTTP or HTTPS URL"})
+		return
+	}
+
 	if ep.Name == "" {
 		ep.Name = ep.URL
 	}
 
 	mu.Lock()
+	for _, existing := range endpoints {
+		if existing.URL == ep.URL {
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			json.NewEncoder(w).Encode(map[string]string{"error": "endpoint already registered"})
+			return
+		}
+	}
 	endpoints = append(endpoints, ep)
 	mu.Unlock()
 

--- a/services/checker/main_test.go
+++ b/services/checker/main_test.go
@@ -260,6 +260,72 @@ func TestDeleteEndpointPreservesOthers(t *testing.T) {
 	}
 }
 
+func TestAddEndpointInvalidURL(t *testing.T) {
+	ResetEndpoints()
+	mux := setupTestMux()
+
+	body := `{"url":"not-a-url"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/endpoints", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+
+	var result map[string]string
+	json.NewDecoder(w.Body).Decode(&result)
+	if result["error"] != "field 'url' must be a valid HTTP or HTTPS URL" {
+		t.Errorf("unexpected error: %s", result["error"])
+	}
+}
+
+func TestAddEndpointDuplicate(t *testing.T) {
+	ResetEndpoints()
+	mux := setupTestMux()
+
+	body := `{"url":"https://example.com","name":"Example"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/endpoints", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", w.Code)
+	}
+
+	// Try adding the same URL again
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/endpoints", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for duplicate, got %d", w.Code)
+	}
+
+	eps := GetEndpoints()
+	if len(eps) != 1 {
+		t.Errorf("expected 1 endpoint, got %d", len(eps))
+	}
+}
+
+func TestAddEndpointFTPScheme(t *testing.T) {
+	ResetEndpoints()
+	mux := setupTestMux()
+
+	body := `{"url":"ftp://files.example.com/data"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/endpoints", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for ftp URL, got %d", w.Code)
+	}
+}
+
 func TestCheckSingleMissingURL(t *testing.T) {
 	mux := setupTestMux()
 


### PR DESCRIPTION
## 変更概要

- checker の `addEndpointHandler` にURLフォーマットバリデーション追加（http/https必須）
- 同一URL登録時に409 Conflictを返すよう修正
- analytics の `requirements.txt` からテスト依存(pytest, flake8)を分離し `requirements-dev.txt` を新規作成
- Makefile を `requirements-dev.txt` に対応
- 新規テストケース3件追加（無効URL, 重複URL, FTPスキーム拒否）

Closes #12

## 動作確認手順

1. `cd services/checker && go test -v ./...` で全25テストがパス
2. `cd services/analytics && pip install -r requirements-dev.txt && pytest -v` で全21テストがパス
3. `make lint` でlintが通る