### PR TITLE
fix: checkSingleHandlerのURL検証追加とgateway DELETEルート追加

### DIFF
--- a/services/checker/main.go
+++ b/services/checker/main.go
@@ -287,6 +287,14 @@ func checkSingleHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	parsed, err := url.ParseRequestURI(body.URL)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "field 'url' must be a valid HTTP or HTTPS URL"})
+		return
+	}
+
 	result := CheckEndpoint(body.URL)
 
 	w.Header().Set("Content-Type", "application/json")

--- a/services/checker/main_test.go
+++ b/services/checker/main_test.go
@@ -339,6 +339,134 @@ func TestCheckSingleMissingURL(t *testing.T) {
 	}
 }
 
+func TestCheckSingleInvalidURL(t *testing.T) {
+	mux := setupTestMux()
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"not a URL", "not-a-url"},
+		{"FTP scheme", "ftp://files.example.com/data"},
+		{"missing host", "http://"},
+		{"file scheme", "file:///etc/passwd"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{"url":"` + tc.url + `"}`
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/check", bytes.NewBufferString(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 for %q, got %d", tc.url, w.Code)
+			}
+
+			var result map[string]string
+			json.NewDecoder(w.Body).Decode(&result)
+			if result["error"] != "field 'url' must be a valid HTTP or HTTPS URL" {
+				t.Errorf("unexpected error: %s", result["error"])
+			}
+		})
+	}
+}
+
+func TestCheckAllMultipleEndpoints(t *testing.T) {
+	ResetEndpoints()
+
+	mockTarget1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockTarget1.Close()
+
+	mockTarget2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer mockTarget2.Close()
+
+	mockAnalytics := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer mockAnalytics.Close()
+
+	SetAnalyticsURL(mockAnalytics.URL)
+	defer SetAnalyticsURL("http://localhost:5000")
+
+	mux := setupTestMux()
+
+	for _, u := range []string{mockTarget1.URL, mockTarget2.URL} {
+		body := `{"url":"` + u + `"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/endpoints", bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d", w.Code)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/check-all", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var result map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&result)
+	total := int(result["total"].(float64))
+	if total != 2 {
+		t.Errorf("expected 2 results, got %d", total)
+	}
+	reported := int(result["reported"].(float64))
+	if reported != 2 {
+		t.Errorf("expected 2 reported, got %d", reported)
+	}
+}
+
+func TestCheckAllAnalyticsNon201(t *testing.T) {
+	ResetEndpoints()
+
+	mockTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockTarget.Close()
+
+	mockAnalytics := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer mockAnalytics.Close()
+
+	SetAnalyticsURL(mockAnalytics.URL)
+	defer SetAnalyticsURL("http://localhost:5000")
+
+	mux := setupTestMux()
+
+	body := `{"url":"` + mockTarget.URL + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/endpoints", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/check-all", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var result map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&result)
+	reported := int(result["reported"].(float64))
+	if reported != 0 {
+		t.Errorf("expected 0 reported when analytics returns 500, got %d", reported)
+	}
+}
+
 func TestCheckSingleWithMockServer(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/services/gateway/src/app.test.ts
+++ b/services/gateway/src/app.test.ts
@@ -161,6 +161,19 @@ describe("Gateway Service", () => {
           if (req.method === "GET" && req.url?.startsWith("/api/v1/records")) {
             res.writeHead(200);
             res.end(JSON.stringify({ records: [], total: 0 }));
+          } else if (req.method === "DELETE" && req.url === "/api/v1/records") {
+            let body = "";
+            req.on("data", (chunk) => (body += chunk));
+            req.on("end", () => {
+              const data = JSON.parse(body);
+              if (data.endpoint === "https://example.com") {
+                res.writeHead(200);
+                res.end(JSON.stringify({ message: "deleted", deleted: 3 }));
+              } else {
+                res.writeHead(200);
+                res.end(JSON.stringify({ message: "deleted", deleted: 0 }));
+              }
+            });
           } else if (req.method === "GET" && req.url === "/api/v1/report") {
             res.writeHead(200);
             res.end(JSON.stringify({ endpoints: {} }));
@@ -190,6 +203,28 @@ describe("Gateway Service", () => {
       const res = await request(app).get("/api/v1/records");
       expect(res.status).toBe(200);
       expect(res.body.records).toEqual([]);
+    });
+
+    it("should proxy GET /api/v1/records with query params", async () => {
+      const res = await request(app).get("/api/v1/records?endpoint=test&limit=5");
+      expect(res.status).toBe(200);
+      expect(res.body.records).toEqual([]);
+    });
+
+    it("should reject DELETE /api/v1/records without endpoint", async () => {
+      const res = await request(app)
+        .delete("/api/v1/records")
+        .send({});
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("endpoint");
+    });
+
+    it("should proxy DELETE /api/v1/records", async () => {
+      const res = await request(app)
+        .delete("/api/v1/records")
+        .send({ endpoint: "https://example.com" });
+      expect(res.status).toBe(200);
+      expect(res.body.deleted).toBe(3);
     });
 
     it("should proxy GET /api/v1/report", async () => {

--- a/services/gateway/src/app.ts
+++ b/services/gateway/src/app.ts
@@ -156,6 +156,20 @@ app.get("/api/v1/records", async (req: Request, res: Response, next: NextFunctio
   }
 });
 
+app.delete("/api/v1/records", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    if (!req.body.endpoint) {
+      res.status(400).json({ error: "Field 'endpoint' is required" });
+      return;
+    }
+    const result = await proxyRequest(analyticsUrl(), "/api/v1/records", "DELETE", req.body);
+    logger.info(`Deleted records for endpoint: ${req.body.endpoint}`);
+    res.status(result.status).json(result.data);
+  } catch (err) {
+    next(err);
+  }
+});
+
 app.get("/api/v1/report", async (_req: Request, res: Response, next: NextFunction) => {
   try {
     const result = await proxyRequest(analyticsUrl(), "/api/v1/report", "GET");


### PR DESCRIPTION
## 変更概要

- `checkSingleHandler` に `url.ParseRequestURI` による URL 検証を追加（SSRF脆弱性の修正）
- gateway に `DELETE /api/v1/records` ルートを追加（analytics サービスの既存機能を外部公開）
- checker テスト追加: 無効URL検証、複数エンドポイント check-all、analytics非201時のreported=0
- gateway テスト追加: DELETE records、query param転送

Closes #14

## 動作確認手順

1. `cd services/checker && go test -v ./...` — 全テストパス
2. `cd services/gateway && npm test` — 全16テストパス
3. `POST /api/v1/check` に `{"url": "ftp://evil.com"}` を送信 → 400エラー
4. `DELETE /api/v1/records` に `{"endpoint": "https://example.com"}` を送信 → 正常動作