### PR TITLE
feat: analyticsサービスにレコードストア上限を追加しメモリリークを防止

### DIFF
--- a/services/analytics/app.py
+++ b/services/analytics/app.py
@@ -16,6 +16,7 @@ logging.basicConfig(
 logger = logging.getLogger("analytics")
 
 PORT = int(os.environ.get("ANALYTICS_PORT", 5000))
+MAX_RECORDS = int(os.environ.get("MAX_RECORDS", "10000"))
 
 # In-memory store for health check results
 health_records: list[dict] = []
@@ -67,6 +68,12 @@ def add_record():
         "healthy": 200 <= status_code < 400,
     }
     health_records.append(record)
+
+    if len(health_records) > MAX_RECORDS:
+        removed = len(health_records) - MAX_RECORDS
+        del health_records[:removed]
+        logger.info("Evicted %d old records (store capped at %d)", removed, MAX_RECORDS)
+
     logger.info(
         "Recorded health check for %s: status=%d, time=%.1fms",
         endpoint, record["status_code"], record["response_time_ms"]

--- a/services/analytics/test_app.py
+++ b/services/analytics/test_app.py
@@ -203,3 +203,48 @@ def test_report_with_data(client):
     assert ep["avg_response_time_ms"] == pytest.approx(116.67, abs=0.01)
     assert ep["min_response_time_ms"] == 50.0
     assert ep["max_response_time_ms"] == 200.0
+
+
+def test_records_store_max_capacity(client, monkeypatch):
+    monkeypatch.setattr("app.MAX_RECORDS", 3)
+    for i in range(5):
+        client.post("/api/v1/records", json={
+            "endpoint": f"https://ep-{i}.com",
+            "status_code": 200,
+            "response_time_ms": 10 + i,
+        })
+    resp = client.get("/api/v1/records")
+    data = resp.get_json()
+    assert data["total"] == 3
+    endpoints = [r["endpoint"] for r in data["records"]]
+    assert "https://ep-0.com" not in endpoints
+    assert "https://ep-1.com" not in endpoints
+    assert "https://ep-4.com" in endpoints
+
+
+def test_records_store_within_capacity(client, monkeypatch):
+    monkeypatch.setattr("app.MAX_RECORDS", 10)
+    for i in range(3):
+        client.post("/api/v1/records", json={
+            "endpoint": f"https://ep-{i}.com",
+            "status_code": 200,
+            "response_time_ms": 10,
+        })
+    resp = client.get("/api/v1/records")
+    data = resp.get_json()
+    assert data["total"] == 3
+
+
+def test_records_store_eviction_preserves_order(client, monkeypatch):
+    monkeypatch.setattr("app.MAX_RECORDS", 2)
+    for i in range(4):
+        client.post("/api/v1/records", json={
+            "endpoint": f"https://ep-{i}.com",
+            "status_code": 200,
+            "response_time_ms": float(i),
+        })
+    resp = client.get("/api/v1/records")
+    data = resp.get_json()
+    assert data["total"] == 2
+    assert data["records"][0]["endpoint"] == "https://ep-2.com"
+    assert data["records"][1]["endpoint"] == "https://ep-3.com"


### PR DESCRIPTION
## 変更概要
- `MAX_RECORDS`環境変数で設定可能なレコードストア上限を追加（デフォルト10000）
- 上限超過時は古いレコードからFIFOで自動削除
- テスト3件追加（上限到達時のeviction・上限内の動作確認・eviction後の順序保持）

Closes #16

## 動作確認
- `flake8 --max-line-length=120 app.py` → PASS
- `pytest -v test_app.py` → 24 passed