### PR TITLE
fix: checker HTTPサーバータイムアウトとリクエストボディサイズ制限を追加

### DIFF
--- a/services/checker/main.go
+++ b/services/checker/main.go
@@ -25,6 +25,12 @@ var (
 	endpoints []Endpoint
 
 	reportTimeout = 5 * time.Second
+
+	readHeaderTimeout time.Duration
+	readTimeout       time.Duration
+	writeTimeout      time.Duration
+	idleTimeout       time.Duration
+	maxBodyBytes      int64
 )
 
 // Endpoint represents a monitored URL.
@@ -54,6 +60,12 @@ func init() {
 	port = getEnv("CHECKER_PORT", "8080")
 	analyticsURL = getEnv("ANALYTICS_URL", "http://localhost:5000")
 	startTime = time.Now()
+
+	readHeaderTimeout = envSeconds("CHECKER_READ_HEADER_TIMEOUT", 5*time.Second)
+	readTimeout = envSeconds("CHECKER_READ_TIMEOUT", 15*time.Second)
+	writeTimeout = envSeconds("CHECKER_WRITE_TIMEOUT", 20*time.Second)
+	idleTimeout = envSeconds("CHECKER_IDLE_TIMEOUT", 60*time.Second)
+	maxBodyBytes = envBytes("CHECKER_MAX_BODY_BYTES", 32*1024)
 }
 
 func getEnv(key, fallback string) string {
@@ -61,6 +73,42 @@ func getEnv(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+func envSeconds(key string, fallback time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
+	return fallback
+}
+
+func envBytes(key string, fallback int64) int64 {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			return n
+		}
+	}
+	return fallback
+}
+
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
+
+func decodeJSONBody(w http.ResponseWriter, r *http.Request, dst interface{}) error {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(dst); err != nil {
+		if err.Error() == "http: request body too large" {
+			writeJSONError(w, http.StatusRequestEntityTooLarge, "request body too large")
+		}
+		return err
+	}
+	return nil
 }
 
 func healthHandler(w http.ResponseWriter, r *http.Request) {
@@ -92,10 +140,11 @@ func addEndpointHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var ep Endpoint
-	if err := json.NewDecoder(r.Body).Decode(&ep); err != nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{"error": "invalid JSON body"})
+	if err := decodeJSONBody(w, r, &ep); err != nil {
+		if err.Error() == "http: request body too large" {
+			return
+		}
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
 
@@ -147,10 +196,15 @@ func deleteEndpointHandler(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		URL string `json:"url"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.URL == "" {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{"error": "field 'url' is required"})
+	if err := decodeJSONBody(w, r, &body); err != nil {
+		if err.Error() == "http: request body too large" {
+			return
+		}
+		writeJSONError(w, http.StatusBadRequest, "field 'url' is required")
+		return
+	}
+	if body.URL == "" {
+		writeJSONError(w, http.StatusBadRequest, "field 'url' is required")
 		return
 	}
 
@@ -280,10 +334,15 @@ func checkSingleHandler(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		URL string `json:"url"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.URL == "" {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{"error": "field 'url' is required"})
+	if err := decodeJSONBody(w, r, &body); err != nil {
+		if err.Error() == "http: request body too large" {
+			return
+		}
+		writeJSONError(w, http.StatusBadRequest, "field 'url' is required")
+		return
+	}
+	if body.URL == "" {
+		writeJSONError(w, http.StatusBadRequest, "field 'url' is required")
 		return
 	}
 
@@ -320,8 +379,16 @@ func main() {
 	mux.HandleFunc("/api/v1/check-all", checkAllHandler)
 
 	addr := ":" + port
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
+	}
 	logger.Printf("Starting Checker Service on %s", addr)
-	if err := http.ListenAndServe(addr, mux); err != nil {
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		logger.Fatalf("Server failed: %v", err)
 	}
 }
@@ -365,6 +432,16 @@ func SetAnalyticsURL(u string) {
 // SetReportTimeout sets the report timeout (for testing).
 func SetReportTimeout(d time.Duration) {
 	reportTimeout = d
+}
+
+// SetMaxBodyBytes sets the request body size limit (for testing).
+func SetMaxBodyBytes(n int64) {
+	maxBodyBytes = n
+}
+
+// GetMaxBodyBytes returns the request body size limit (for testing).
+func GetMaxBodyBytes() int64 {
+	return maxBodyBytes
 }
 
 // ParsePort converts port string to int safely.

--- a/services/checker/main_test.go
+++ b/services/checker/main_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -666,6 +667,94 @@ func TestReportToAnalyticsUnreachable(t *testing.T) {
 	}
 	if reportToAnalytics(result) {
 		t.Error("expected reportToAnalytics to return false for unreachable server")
+	}
+}
+
+func TestAddEndpointBodyTooLarge(t *testing.T) {
+	ResetEndpoints()
+	old := GetMaxBodyBytes()
+	SetMaxBodyBytes(64)
+	defer SetMaxBodyBytes(old)
+
+	largeName := strings.Repeat("a", 256)
+	body := []byte(`{"url":"http://x","name":"` + largeName + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/endpoints", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	addEndpointHandler(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d", w.Code)
+	}
+	var resp map[string]string
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp["error"] != "request body too large" {
+		t.Errorf("expected error 'request body too large', got %q", resp["error"])
+	}
+}
+
+func TestDeleteEndpointBodyTooLarge(t *testing.T) {
+	ResetEndpoints()
+	old := GetMaxBodyBytes()
+	SetMaxBodyBytes(32)
+	defer SetMaxBodyBytes(old)
+
+	body := []byte(`{"url":"http://example.com/` + strings.Repeat("p", 256) + `"}`)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/endpoints", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	deleteEndpointHandler(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d", w.Code)
+	}
+}
+
+func TestCheckSingleBodyTooLarge(t *testing.T) {
+	old := GetMaxBodyBytes()
+	SetMaxBodyBytes(32)
+	defer SetMaxBodyBytes(old)
+
+	body := []byte(`{"url":"http://example.com/` + strings.Repeat("p", 256) + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/check", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	checkSingleHandler(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d", w.Code)
+	}
+}
+
+func TestEnvSecondsFallbackAndOverride(t *testing.T) {
+	const key = "TEST_CHECKER_ENV_SECONDS_X"
+	t.Setenv(key, "")
+	if got := envSeconds(key, 7*time.Second); got != 7*time.Second {
+		t.Fatalf("expected fallback 7s, got %v", got)
+	}
+	t.Setenv(key, "13")
+	if got := envSeconds(key, 7*time.Second); got != 13*time.Second {
+		t.Fatalf("expected 13s, got %v", got)
+	}
+	t.Setenv(key, "garbage")
+	if got := envSeconds(key, 7*time.Second); got != 7*time.Second {
+		t.Fatalf("expected fallback for invalid, got %v", got)
+	}
+}
+
+func TestEnvBytesFallbackAndOverride(t *testing.T) {
+	const key = "TEST_CHECKER_ENV_BYTES_X"
+	t.Setenv(key, "")
+	if got := envBytes(key, 1024); got != 1024 {
+		t.Fatalf("expected fallback 1024, got %d", got)
+	}
+	t.Setenv(key, "2048")
+	if got := envBytes(key, 1024); got != 2048 {
+		t.Fatalf("expected 2048, got %d", got)
+	}
+	t.Setenv(key, "-5")
+	if got := envBytes(key, 1024); got != 1024 {
+		t.Fatalf("expected fallback for negative, got %d", got)
 	}
 }
 


### PR DESCRIPTION
## 概要

- `services/checker/main.go` の `http.ListenAndServe` を `http.Server{ReadHeaderTimeout, ReadTimeout, WriteTimeout, IdleTimeout}` 構成に置き換え
  - 既定: `ReadHeaderTimeout=5s` / `ReadTimeout=15s` / `WriteTimeout=20s` / `IdleTimeout=60s`
  - `CHECKER_READ_HEADER_TIMEOUT` / `CHECKER_READ_TIMEOUT` / `CHECKER_WRITE_TIMEOUT` / `CHECKER_IDLE_TIMEOUT`（秒指定）で上書き可能
- `addEndpointHandler` / `deleteEndpointHandler` / `checkSingleHandler` で `http.MaxBytesReader` を適用
  - 既定 32KB、`CHECKER_MAX_BODY_BYTES` で上書き可能
  - 上限超過時は 413 (Request Entity Too Large) を返却
- 共通ヘルパ `envSeconds` / `envBytes` / `decodeJSONBody` / `writeJSONError` を追加し、エラー応答の重複を整理
- テスト用 `SetMaxBodyBytes` / `GetMaxBodyBytes` を export

Closes #18

## 動作確認手順

```bash
cd services/checker
go vet ./...
go test -race -count=1 ./...
```

- 既存テスト 30 件はすべてパス（互換維持）
- 追加テスト 5 件：
  - `POST /api/v1/endpoints` のボディサイズ超過で 413
  - `DELETE /api/v1/endpoints` のボディサイズ超過で 413
  - `POST /api/v1/check` のボディサイズ超過で 413
  - `envSeconds` のフォールバック・上書き・不正値処理
  - `envBytes` のフォールバック・上書き・負値処理
