### PR TITLE
feat: /api/v1/report に endpoint/since/until フィルタを追加（gateway 経由含む）

### DIFF
--- a/services/analytics/app.py
+++ b/services/analytics/app.py
@@ -233,11 +233,43 @@ def delete_records():
 
 @app.route("/api/v1/report", methods=["GET"])
 def report():
-    if not health_records:
+    endpoint_filter = request.args.get("endpoint")
+    since_raw = request.args.get("since")
+    until_raw = request.args.get("until")
+
+    since = until = None
+    try:
+        if since_raw is not None:
+            since = _parse_iso8601_arg(since_raw, "since")
+        if until_raw is not None:
+            until = _parse_iso8601_arg(until_raw, "until")
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+    if since is not None and until is not None and until < since:
+        return jsonify({"error": "Query parameter 'until' must be greater than or equal to 'since'"}), 400
+
+    filtered = health_records
+    if endpoint_filter:
+        filtered = [r for r in filtered if r["endpoint"] == endpoint_filter]
+    if since is not None or until is not None:
+        narrowed = []
+        for r in filtered:
+            checked_at = _record_checked_at(r)
+            if checked_at is None:
+                continue
+            if since is not None and checked_at < since:
+                continue
+            if until is not None and checked_at > until:
+                continue
+            narrowed.append(r)
+        filtered = narrowed
+
+    if not filtered:
         return jsonify({"message": "No records available", "endpoints": {}})
 
     endpoints: dict[str, dict] = {}
-    for r in health_records:
+    for r in filtered:
         ep = r["endpoint"]
         if ep not in endpoints:
             endpoints[ep] = {

--- a/services/analytics/test_app.py
+++ b/services/analytics/test_app.py
@@ -470,3 +470,96 @@ def test_records_store_eviction_preserves_order(client, monkeypatch):
     assert data["total"] == 2
     assert data["records"][0]["endpoint"] == "https://ep-2.com"
     assert data["records"][1]["endpoint"] == "https://ep-3.com"
+
+
+def test_report_filters_by_endpoint(client):
+    health_records.append({
+        "endpoint": "https://a.example.com/h",
+        "status_code": 200,
+        "response_time_ms": 10.0,
+        "checked_at": "2026-01-01T00:00:00+00:00",
+        "healthy": True,
+    })
+    health_records.append({
+        "endpoint": "https://b.example.com/h",
+        "status_code": 500,
+        "response_time_ms": 100.0,
+        "checked_at": "2026-01-01T00:00:00+00:00",
+        "healthy": False,
+    })
+    resp = client.get("/api/v1/report?endpoint=https://a.example.com/h")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "https://a.example.com/h" in data["endpoints"]
+    assert "https://b.example.com/h" not in data["endpoints"]
+
+
+def test_report_filters_by_since(client):
+    health_records.append({
+        "endpoint": "https://x.example.com/h",
+        "status_code": 200,
+        "response_time_ms": 10.0,
+        "checked_at": "2024-01-01T00:00:00+00:00",
+        "healthy": True,
+    })
+    health_records.append({
+        "endpoint": "https://x.example.com/h",
+        "status_code": 200,
+        "response_time_ms": 20.0,
+        "checked_at": "2026-06-01T00:00:00+00:00",
+        "healthy": True,
+    })
+    resp = client.get("/api/v1/report?since=2026-01-01T00:00:00Z")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    stats = data["endpoints"]["https://x.example.com/h"]
+    assert stats["total_checks"] == 1
+    assert stats["avg_response_time_ms"] == 20.0
+
+
+def test_report_filters_by_until(client):
+    health_records.append({
+        "endpoint": "https://x.example.com/h",
+        "status_code": 200,
+        "response_time_ms": 10.0,
+        "checked_at": "2024-01-01T00:00:00+00:00",
+        "healthy": True,
+    })
+    health_records.append({
+        "endpoint": "https://x.example.com/h",
+        "status_code": 200,
+        "response_time_ms": 20.0,
+        "checked_at": "2026-06-01T00:00:00+00:00",
+        "healthy": True,
+    })
+    resp = client.get("/api/v1/report?until=2025-01-01T00:00:00Z")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    stats = data["endpoints"]["https://x.example.com/h"]
+    assert stats["total_checks"] == 1
+    assert stats["avg_response_time_ms"] == 10.0
+
+
+def test_report_rejects_invalid_since(client):
+    resp = client.get("/api/v1/report?since=garbage")
+    assert resp.status_code == 400
+    assert "since" in resp.get_json()["error"]
+
+
+def test_report_rejects_until_before_since(client):
+    resp = client.get("/api/v1/report?since=2026-06-01T00:00:00Z&until=2024-01-01T00:00:00Z")
+    assert resp.status_code == 400
+
+
+def test_report_returns_no_records_when_filter_excludes_all(client):
+    health_records.append({
+        "endpoint": "https://x.example.com/h",
+        "status_code": 200,
+        "response_time_ms": 10.0,
+        "checked_at": "2024-01-01T00:00:00+00:00",
+        "healthy": True,
+    })
+    resp = client.get("/api/v1/report?endpoint=https://does-not-exist.example/h")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["endpoints"] == {}

--- a/services/gateway/src/app.test.ts
+++ b/services/gateway/src/app.test.ts
@@ -174,9 +174,11 @@ describe("Gateway Service", () => {
                 res.end(JSON.stringify({ message: "deleted", deleted: 0 }));
               }
             });
-          } else if (req.method === "GET" && req.url === "/api/v1/report") {
+          } else if (req.method === "GET" && req.url?.startsWith("/api/v1/report")) {
             res.writeHead(200);
-            res.end(JSON.stringify({ endpoints: {} }));
+            res.end(
+              JSON.stringify({ endpoints: {}, forwarded_query: req.url.split("?")[1] || "" })
+            );
           } else if (req.url === "/health") {
             res.writeHead(200);
             res.end(JSON.stringify({ status: "ok", service: "analytics" }));
@@ -231,6 +233,16 @@ describe("Gateway Service", () => {
       const res = await request(app).get("/api/v1/report");
       expect(res.status).toBe(200);
       expect(res.body.endpoints).toEqual({});
+      expect(res.body.forwarded_query).toBe("");
+    });
+
+    it("should proxy GET /api/v1/report with query params", async () => {
+      const res = await request(app).get(
+        "/api/v1/report?endpoint=https%3A%2F%2Fa.example.com%2Fh&since=2026-01-01T00%3A00%3A00Z"
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.forwarded_query).toContain("endpoint=https%3A%2F%2Fa.example.com%2Fh");
+      expect(res.body.forwarded_query).toContain("since=2026-01-01T00%3A00%3A00Z");
     });
   });
 

--- a/services/gateway/src/app.ts
+++ b/services/gateway/src/app.ts
@@ -170,9 +170,11 @@ app.delete("/api/v1/records", async (req: Request, res: Response, next: NextFunc
   }
 });
 
-app.get("/api/v1/report", async (_req: Request, res: Response, next: NextFunction) => {
+app.get("/api/v1/report", async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const result = await proxyRequest(analyticsUrl(), "/api/v1/report", "GET");
+    const query = req.url.split("?")[1] || "";
+    const path = query ? `/api/v1/report?${query}` : "/api/v1/report";
+    const result = await proxyRequest(analyticsUrl(), path, "GET");
     res.status(result.status).json(result.data);
   } catch (err) {
     next(err);


### PR DESCRIPTION
## 概要
- analytics: `GET /api/v1/report` に `endpoint` / `since` / `until` クエリを追加
- 既存の `_parse_iso8601_arg` / `_record_checked_at` を再利用し、`/api/v1/records` と仕様を揃える
- gateway: `/api/v1/report` プロキシでクエリ文字列をそのまま転送
- 双方にテスト追加（フィルタ動作・バリデーション・転送）

## 動作確認
- `cd services/analytics && flake8 --max-line-length=120 . && pytest -v` → 55 passed
- `cd services/gateway && npm run lint && npm test` → 17 passed

Closes #24