### PR TITLE
feat: analytics /api/v1/records と /api/v1/report に healthy フィルタを追加

### DIFF
--- a/services/analytics/app.py
+++ b/services/analytics/app.py
@@ -140,6 +140,48 @@ def _record_checked_at(record: dict) -> datetime | None:
         return None
 
 
+_HEALTHY_TRUE = {"true", "1", "yes"}
+_HEALTHY_FALSE = {"false", "0", "no"}
+
+
+def _parse_bool_arg(value: str, name: str) -> bool:
+    lowered = value.strip().lower()
+    if lowered in _HEALTHY_TRUE:
+        return True
+    if lowered in _HEALTHY_FALSE:
+        return False
+    raise ValueError(
+        f"Query parameter '{name}' must be one of: true, false, 1, 0, yes, no"
+    )
+
+
+def _filter_records(
+    records: list[dict],
+    endpoint: str | None,
+    since: datetime | None,
+    until: datetime | None,
+    healthy: bool | None,
+) -> list[dict]:
+    filtered = records
+    if endpoint:
+        filtered = [r for r in filtered if r["endpoint"] == endpoint]
+    if healthy is not None:
+        filtered = [r for r in filtered if bool(r.get("healthy")) == healthy]
+    if since is not None or until is not None:
+        narrowed = []
+        for r in filtered:
+            checked_at = _record_checked_at(r)
+            if checked_at is None:
+                continue
+            if since is not None and checked_at < since:
+                continue
+            if until is not None and checked_at > until:
+                continue
+            narrowed.append(r)
+        filtered = narrowed
+    return filtered
+
+
 @app.route("/api/v1/records", methods=["GET"])
 def list_records():
     endpoint = request.args.get("endpoint")
@@ -147,6 +189,7 @@ def list_records():
     offset_raw = request.args.get("offset")
     since_raw = request.args.get("since")
     until_raw = request.args.get("until")
+    healthy_raw = request.args.get("healthy")
 
     if limit_raw is None:
         limit = LIST_DEFAULT_LIMIT
@@ -182,27 +225,20 @@ def list_records():
     if since is not None and until is not None and until < since:
         return jsonify({"error": "Query parameter 'until' must be greater than or equal to 'since'"}), 400
 
-    filtered = health_records
-    if endpoint:
-        filtered = [r for r in filtered if r["endpoint"] == endpoint]
-    if since is not None or until is not None:
-        narrowed = []
-        for r in filtered:
-            checked_at = _record_checked_at(r)
-            if checked_at is None:
-                continue
-            if since is not None and checked_at < since:
-                continue
-            if until is not None and checked_at > until:
-                continue
-            narrowed.append(r)
-        filtered = narrowed
+    healthy: bool | None = None
+    if healthy_raw is not None:
+        try:
+            healthy = _parse_bool_arg(healthy_raw, "healthy")
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
+
+    filtered = _filter_records(health_records, endpoint, since, until, healthy)
 
     total = len(filtered)
     result = filtered[offset:offset + limit]
     logger.info(
-        "Listed %d records (filter=%s, limit=%d, offset=%d, total=%d)",
-        len(result), endpoint, limit, offset, total,
+        "Listed %d records (filter=%s, healthy=%s, limit=%d, offset=%d, total=%d)",
+        len(result), endpoint, healthy, limit, offset, total,
     )
     return jsonify({
         "records": result,
@@ -236,6 +272,7 @@ def report():
     endpoint_filter = request.args.get("endpoint")
     since_raw = request.args.get("since")
     until_raw = request.args.get("until")
+    healthy_raw = request.args.get("healthy")
 
     since = until = None
     try:
@@ -249,21 +286,14 @@ def report():
     if since is not None and until is not None and until < since:
         return jsonify({"error": "Query parameter 'until' must be greater than or equal to 'since'"}), 400
 
-    filtered = health_records
-    if endpoint_filter:
-        filtered = [r for r in filtered if r["endpoint"] == endpoint_filter]
-    if since is not None or until is not None:
-        narrowed = []
-        for r in filtered:
-            checked_at = _record_checked_at(r)
-            if checked_at is None:
-                continue
-            if since is not None and checked_at < since:
-                continue
-            if until is not None and checked_at > until:
-                continue
-            narrowed.append(r)
-        filtered = narrowed
+    healthy: bool | None = None
+    if healthy_raw is not None:
+        try:
+            healthy = _parse_bool_arg(healthy_raw, "healthy")
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
+
+    filtered = _filter_records(health_records, endpoint_filter, since, until, healthy)
 
     if not filtered:
         return jsonify({"message": "No records available", "endpoints": {}})

--- a/services/analytics/test_app.py
+++ b/services/analytics/test_app.py
@@ -563,3 +563,61 @@ def test_report_returns_no_records_when_filter_excludes_all(client):
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["endpoints"] == {}
+
+
+def test_list_records_filter_healthy_true(client):
+    client.post("/api/v1/records", json={"endpoint": "https://a.com", "status_code": 200, "response_time_ms": 10})
+    client.post("/api/v1/records", json={"endpoint": "https://a.com", "status_code": 500, "response_time_ms": 20})
+    resp = client.get("/api/v1/records?healthy=true")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total"] == 1
+    assert data["records"][0]["status_code"] == 200
+
+
+def test_list_records_filter_healthy_false(client):
+    client.post("/api/v1/records", json={"endpoint": "https://a.com", "status_code": 200, "response_time_ms": 10})
+    client.post("/api/v1/records", json={"endpoint": "https://a.com", "status_code": 503, "response_time_ms": 20})
+    client.post("/api/v1/records", json={"endpoint": "https://a.com", "status_code": 502, "response_time_ms": 30})
+    resp = client.get("/api/v1/records?healthy=false")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total"] == 2
+    assert all(r["healthy"] is False for r in data["records"])
+
+
+def test_list_records_healthy_accepts_aliases(client):
+    client.post("/api/v1/records", json={"endpoint": "https://a.com", "status_code": 200, "response_time_ms": 10})
+    client.post("/api/v1/records", json={"endpoint": "https://a.com", "status_code": 500, "response_time_ms": 20})
+    for alias in ("1", "yes", "TRUE"):
+        resp = client.get(f"/api/v1/records?healthy={alias}")
+        assert resp.status_code == 200
+        assert resp.get_json()["total"] == 1
+    for alias in ("0", "no", "FALSE"):
+        resp = client.get(f"/api/v1/records?healthy={alias}")
+        assert resp.status_code == 200
+        assert resp.get_json()["total"] == 1
+
+
+def test_list_records_healthy_rejects_invalid(client):
+    resp = client.get("/api/v1/records?healthy=maybe")
+    assert resp.status_code == 400
+    assert "healthy" in resp.get_json()["error"]
+
+
+def test_report_filter_healthy_only_unhealthy(client):
+    client.post("/api/v1/records", json={"endpoint": "https://a.com", "status_code": 200, "response_time_ms": 10})
+    client.post("/api/v1/records", json={"endpoint": "https://a.com", "status_code": 500, "response_time_ms": 50})
+    client.post("/api/v1/records", json={"endpoint": "https://a.com", "status_code": 502, "response_time_ms": 100})
+    resp = client.get("/api/v1/report?healthy=false")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    stats = data["endpoints"]["https://a.com"]
+    assert stats["total_checks"] == 2
+    assert stats["healthy_checks"] == 0
+    assert stats["uptime_percent"] == 0
+
+
+def test_report_healthy_rejects_invalid(client):
+    resp = client.get("/api/v1/report?healthy=meh")
+    assert resp.status_code == 400


### PR DESCRIPTION
## 概要

- `GET /api/v1/records` と `GET /api/v1/report` に `healthy` クエリパラメータを追加
  - 受け付ける値: `true / false / 1 / 0 / yes / no`（大文字小文字無視）
  - 不正な値は 400
- 重複していた endpoint / since / until / healthy のフィルタロジックを `_filter_records` に集約してリファクタ
- gateway はクエリストリングを素通しでプロキシしているため変更不要
- analytics 側に 7 件のユニットテストを追加

## 対応 Issue

Closes #26

## 動作確認

- [x] `cd services/analytics && pytest -v` → 61 件すべてパス
- [x] `cd services/analytics && flake8 --max-line-length=120 .` → 警告なし