### PR TITLE
feat: analytics の records / report に status_code 完全一致フィルタを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ All endpoints are accessible through the Gateway at `http://localhost:3000`.
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | `/api/v1/records` | List health check records |
-| `GET` | `/api/v1/records?endpoint=URL&limit=N&offset=N&since=ISO&until=ISO` | Filter records by endpoint and time range（`limit` は 1〜`LIST_MAX_LIMIT`、`offset` は 0 以上、`since`/`until` は ISO 8601） |
+| `GET` | `/api/v1/records?endpoint=URL&limit=N&offset=N&since=ISO&until=ISO&healthy=true&status_code=200` | Filter records by endpoint / time range / healthy / status_code（`limit` は 1〜`LIST_MAX_LIMIT`、`offset` は 0 以上、`since`/`until` は ISO 8601、`status_code` は 100〜599） |
 | `POST` | `/api/v1/records` | Add a record（`endpoint` は `http(s)://` 必須・最大 `MAX_ENDPOINT_LENGTH`、`status_code` は 100〜599、`response_time_ms` は 0〜`MAX_RESPONSE_TIME_MS` の有限数、`checked_at` は ISO 8601） |
 | `DELETE` | `/api/v1/records?endpoint=URL` | 指定エンドポイントのレコードを削除 |
-| `GET` | `/api/v1/report` | Get uptime and performance report |
+| `GET` | `/api/v1/report?endpoint=URL&since=ISO&until=ISO&healthy=true&status_code=200` | Get uptime and performance report（`status_code` は 100〜599 で完全一致絞り込み） |
 
 ### Usage Examples
 

--- a/services/analytics/app.py
+++ b/services/analytics/app.py
@@ -155,18 +155,35 @@ def _parse_bool_arg(value: str, name: str) -> bool:
     )
 
 
+def _parse_status_code_arg(value: str, name: str) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as e:
+        raise ValueError(
+            f"Query parameter '{name}' must be an integer"
+        ) from e
+    if not (100 <= parsed <= 599):
+        raise ValueError(
+            f"Query parameter '{name}' must be between 100 and 599"
+        )
+    return parsed
+
+
 def _filter_records(
     records: list[dict],
     endpoint: str | None,
     since: datetime | None,
     until: datetime | None,
     healthy: bool | None,
+    status_code: int | None = None,
 ) -> list[dict]:
     filtered = records
     if endpoint:
         filtered = [r for r in filtered if r["endpoint"] == endpoint]
     if healthy is not None:
         filtered = [r for r in filtered if bool(r.get("healthy")) == healthy]
+    if status_code is not None:
+        filtered = [r for r in filtered if r.get("status_code") == status_code]
     if since is not None or until is not None:
         narrowed = []
         for r in filtered:
@@ -190,6 +207,7 @@ def list_records():
     since_raw = request.args.get("since")
     until_raw = request.args.get("until")
     healthy_raw = request.args.get("healthy")
+    status_code_raw = request.args.get("status_code")
 
     if limit_raw is None:
         limit = LIST_DEFAULT_LIMIT
@@ -232,13 +250,22 @@ def list_records():
         except ValueError as e:
             return jsonify({"error": str(e)}), 400
 
-    filtered = _filter_records(health_records, endpoint, since, until, healthy)
+    status_code: int | None = None
+    if status_code_raw is not None:
+        try:
+            status_code = _parse_status_code_arg(status_code_raw, "status_code")
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
+
+    filtered = _filter_records(
+        health_records, endpoint, since, until, healthy, status_code,
+    )
 
     total = len(filtered)
     result = filtered[offset:offset + limit]
     logger.info(
-        "Listed %d records (filter=%s, healthy=%s, limit=%d, offset=%d, total=%d)",
-        len(result), endpoint, healthy, limit, offset, total,
+        "Listed %d records (filter=%s, healthy=%s, status_code=%s, limit=%d, offset=%d, total=%d)",
+        len(result), endpoint, healthy, status_code, limit, offset, total,
     )
     return jsonify({
         "records": result,
@@ -273,6 +300,7 @@ def report():
     since_raw = request.args.get("since")
     until_raw = request.args.get("until")
     healthy_raw = request.args.get("healthy")
+    status_code_raw = request.args.get("status_code")
 
     since = until = None
     try:
@@ -293,7 +321,16 @@ def report():
         except ValueError as e:
             return jsonify({"error": str(e)}), 400
 
-    filtered = _filter_records(health_records, endpoint_filter, since, until, healthy)
+    status_code: int | None = None
+    if status_code_raw is not None:
+        try:
+            status_code = _parse_status_code_arg(status_code_raw, "status_code")
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
+
+    filtered = _filter_records(
+        health_records, endpoint_filter, since, until, healthy, status_code,
+    )
 
     if not filtered:
         return jsonify({"message": "No records available", "endpoints": {}})

--- a/services/analytics/test_app.py
+++ b/services/analytics/test_app.py
@@ -621,3 +621,60 @@ def test_report_filter_healthy_only_unhealthy(client):
 def test_report_healthy_rejects_invalid(client):
     resp = client.get("/api/v1/report?healthy=meh")
     assert resp.status_code == 400
+
+
+def test_list_records_filter_status_code(client):
+    client.post("/api/v1/records", json={"endpoint": "https://a.com", "status_code": 200, "response_time_ms": 10})
+    client.post("/api/v1/records", json={"endpoint": "https://a.com", "status_code": 404, "response_time_ms": 20})
+    client.post("/api/v1/records", json={"endpoint": "https://a.com", "status_code": 500, "response_time_ms": 30})
+    client.post("/api/v1/records", json={"endpoint": "https://b.com", "status_code": 404, "response_time_ms": 40})
+    resp = client.get("/api/v1/records?status_code=404")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total"] == 2
+    assert all(r["status_code"] == 404 for r in data["records"])
+
+
+def test_list_records_status_code_combined_with_endpoint(client):
+    client.post("/api/v1/records", json={"endpoint": "https://a.com", "status_code": 200, "response_time_ms": 10})
+    client.post("/api/v1/records", json={"endpoint": "https://a.com", "status_code": 500, "response_time_ms": 20})
+    client.post("/api/v1/records", json={"endpoint": "https://b.com", "status_code": 500, "response_time_ms": 30})
+    resp = client.get("/api/v1/records?endpoint=https://a.com&status_code=500")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total"] == 1
+    assert data["records"][0]["endpoint"] == "https://a.com"
+    assert data["records"][0]["status_code"] == 500
+
+
+def test_list_records_status_code_rejects_non_integer(client):
+    resp = client.get("/api/v1/records?status_code=abc")
+    assert resp.status_code == 400
+    assert "status_code" in resp.get_json()["error"]
+
+
+def test_list_records_status_code_rejects_out_of_range(client):
+    resp = client.get("/api/v1/records?status_code=42")
+    assert resp.status_code == 400
+    assert "status_code" in resp.get_json()["error"]
+    resp = client.get("/api/v1/records?status_code=999")
+    assert resp.status_code == 400
+
+
+def test_report_filter_status_code(client):
+    client.post("/api/v1/records", json={"endpoint": "https://a.com", "status_code": 200, "response_time_ms": 10})
+    client.post("/api/v1/records", json={"endpoint": "https://a.com", "status_code": 500, "response_time_ms": 50})
+    client.post("/api/v1/records", json={"endpoint": "https://b.com", "status_code": 500, "response_time_ms": 70})
+    resp = client.get("/api/v1/report?status_code=500")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    eps = data["endpoints"]
+    assert set(eps.keys()) == {"https://a.com", "https://b.com"}
+    assert eps["https://a.com"]["total_checks"] == 1
+    assert eps["https://b.com"]["total_checks"] == 1
+
+
+def test_report_status_code_rejects_invalid(client):
+    resp = client.get("/api/v1/report?status_code=notanint")
+    assert resp.status_code == 400
+    assert "status_code" in resp.get_json()["error"]


### PR DESCRIPTION
## 変更概要

- `services/analytics/app.py`:
  - `_parse_status_code_arg` ヘルパーを追加（100〜599 の整数、範囲外/非整数は ValueError）
  - `_filter_records` に `status_code` 引数を追加
  - `GET /api/v1/records` / `GET /api/v1/report` に `status_code` クエリパラメータを実装し、既存の `endpoint` / `healthy` / `since` / `until` と AND 結合
- `services/analytics/test_app.py`: 単体フィルタ / endpoint との AND / 非整数 / 範囲外 / report 用のテストを追加（合計 +6）
- `README.md`: API テーブルを更新

Gateway は `req.url` のクエリストリングをそのまま転送する設計のため変更不要。

## 対応 Issue

- Closes #28

## 動作確認手順

```bash
cd services/analytics
flake8 --max-line-length=120 app.py    # clean
pytest -q                              # 67 tests pass
```

動作確認例:

```bash
curl 'http://localhost:3000/api/v1/records?status_code=500'
curl 'http://localhost:3000/api/v1/report?endpoint=https://x&status_code=200'
```