### PR TITLE
feat(analytics): スレッドセーフ化・レポートにパーセンタイル追加・records にソート機能

### DIFF
--- a/services/analytics/app.py
+++ b/services/analytics/app.py
@@ -3,6 +3,7 @@
 import logging
 import math
 import os
+import threading
 import time
 from datetime import datetime, timezone
 from flask import Flask, jsonify, request
@@ -25,7 +26,25 @@ LIST_MAX_LIMIT = int(os.environ.get("LIST_MAX_LIMIT", "1000"))
 
 # In-memory store for health check results
 health_records: list[dict] = []
+records_lock = threading.Lock()
 start_time = time.time()
+
+ALLOWED_SORT_FIELDS = {"checked_at", "endpoint", "response_time_ms", "status_code"}
+ALLOWED_SORT_ORDERS = {"asc", "desc"}
+
+
+def _percentile(sorted_values: list[float], pct: float) -> float:
+    if not sorted_values:
+        return 0.0
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    rank = (pct / 100.0) * (len(sorted_values) - 1)
+    lower = int(math.floor(rank))
+    upper = int(math.ceil(rank))
+    if lower == upper:
+        return sorted_values[lower]
+    weight = rank - lower
+    return sorted_values[lower] * (1 - weight) + sorted_values[upper] * weight
 
 
 @app.route("/health")
@@ -109,12 +128,12 @@ def add_record():
         "checked_at": checked_at_value,
         "healthy": 200 <= status_code < 400,
     }
-    health_records.append(record)
-
-    if len(health_records) > MAX_RECORDS:
-        removed = len(health_records) - MAX_RECORDS
-        del health_records[:removed]
-        logger.info("Evicted %d old records (store capped at %d)", removed, MAX_RECORDS)
+    with records_lock:
+        health_records.append(record)
+        if len(health_records) > MAX_RECORDS:
+            removed = len(health_records) - MAX_RECORDS
+            del health_records[:removed]
+            logger.info("Evicted %d old records (store capped at %d)", removed, MAX_RECORDS)
 
     logger.info(
         "Recorded health check for %s: status=%d, time=%.1fms",
@@ -257,9 +276,23 @@ def list_records():
         except ValueError as e:
             return jsonify({"error": str(e)}), 400
 
-    filtered = _filter_records(
-        health_records, endpoint, since, until, healthy, status_code,
-    )
+    sort_field = request.args.get("sort", "checked_at")
+    sort_order = request.args.get("order", "asc")
+    if sort_field not in ALLOWED_SORT_FIELDS:
+        return jsonify({
+            "error": "Query parameter 'sort' must be one of: " + ", ".join(sorted(ALLOWED_SORT_FIELDS)),
+        }), 400
+    if sort_order not in ALLOWED_SORT_ORDERS:
+        return jsonify({
+            "error": "Query parameter 'order' must be one of: " + ", ".join(sorted(ALLOWED_SORT_ORDERS)),
+        }), 400
+
+    with records_lock:
+        snapshot = list(health_records)
+    filtered = _filter_records(snapshot, endpoint, since, until, healthy, status_code)
+
+    reverse = sort_order == "desc"
+    filtered.sort(key=lambda r: r.get(sort_field, ""), reverse=reverse)
 
     total = len(filtered)
     result = filtered[offset:offset + limit]
@@ -272,6 +305,8 @@ def list_records():
         "total": total,
         "limit": limit,
         "offset": offset,
+        "sort": sort_field,
+        "order": sort_order,
     })
 
 
@@ -282,9 +317,10 @@ def delete_records():
         logger.warning("Delete request missing endpoint parameter")
         return jsonify({"error": "Query parameter 'endpoint' is required"}), 400
 
-    before_count = len(health_records)
-    health_records[:] = [r for r in health_records if r["endpoint"] != endpoint]
-    deleted_count = before_count - len(health_records)
+    with records_lock:
+        before_count = len(health_records)
+        health_records[:] = [r for r in health_records if r["endpoint"] != endpoint]
+        deleted_count = before_count - len(health_records)
 
     if deleted_count == 0:
         logger.info("No records found for deletion: %s", endpoint)
@@ -328,9 +364,9 @@ def report():
         except ValueError as e:
             return jsonify({"error": str(e)}), 400
 
-    filtered = _filter_records(
-        health_records, endpoint_filter, since, until, healthy, status_code,
-    )
+    with records_lock:
+        snapshot = list(health_records)
+    filtered = _filter_records(snapshot, endpoint_filter, since, until, healthy, status_code)
 
     if not filtered:
         return jsonify({"message": "No records available", "endpoints": {}})
@@ -345,6 +381,7 @@ def report():
                 "total_response_time_ms": 0.0,
                 "min_response_time_ms": float("inf"),
                 "max_response_time_ms": 0.0,
+                "response_times": [],
             }
         stats = endpoints[ep]
         stats["total_checks"] += 1
@@ -353,10 +390,12 @@ def report():
         stats["total_response_time_ms"] += r["response_time_ms"]
         stats["min_response_time_ms"] = min(stats["min_response_time_ms"], r["response_time_ms"])
         stats["max_response_time_ms"] = max(stats["max_response_time_ms"], r["response_time_ms"])
+        stats["response_times"].append(r["response_time_ms"])
 
     report_data: dict[str, dict] = {}
     for ep, stats in endpoints.items():
         total = stats["total_checks"]
+        sorted_times = sorted(stats["response_times"])
         report_data[ep] = {
             "total_checks": total,
             "healthy_checks": stats["healthy_checks"],
@@ -364,6 +403,9 @@ def report():
             "avg_response_time_ms": round(stats["total_response_time_ms"] / total, 2) if total > 0 else 0,
             "min_response_time_ms": round(stats["min_response_time_ms"], 2),
             "max_response_time_ms": round(stats["max_response_time_ms"], 2),
+            "p50_response_time_ms": round(_percentile(sorted_times, 50), 2),
+            "p95_response_time_ms": round(_percentile(sorted_times, 95), 2),
+            "p99_response_time_ms": round(_percentile(sorted_times, 99), 2),
         }
 
     logger.info("Generated report for %d endpoints", len(report_data))

--- a/services/analytics/test_app.py
+++ b/services/analytics/test_app.py
@@ -678,3 +678,122 @@ def test_report_status_code_rejects_invalid(client):
     resp = client.get("/api/v1/report?status_code=notanint")
     assert resp.status_code == 400
     assert "status_code" in resp.get_json()["error"]
+
+
+def test_report_includes_percentiles(client):
+    for i in range(1, 11):
+        client.post(
+            "/api/v1/records",
+            json={
+                "endpoint": "https://percentile.test",
+                "status_code": 200,
+                "response_time_ms": float(i * 10),
+            },
+        )
+    data = client.get("/api/v1/report").get_json()
+    stats = data["endpoints"]["https://percentile.test"]
+    assert stats["min_response_time_ms"] == 10.0
+    assert stats["max_response_time_ms"] == 100.0
+    assert stats["p50_response_time_ms"] == 55.0
+    assert stats["p95_response_time_ms"] >= 90.0
+    assert stats["p99_response_time_ms"] >= 95.0
+
+
+def test_report_percentile_single_sample(client):
+    client.post(
+        "/api/v1/records",
+        json={
+            "endpoint": "https://one.test",
+            "status_code": 200,
+            "response_time_ms": 42.0,
+        },
+    )
+    stats = client.get("/api/v1/report").get_json()["endpoints"]["https://one.test"]
+    assert stats["p50_response_time_ms"] == 42.0
+    assert stats["p95_response_time_ms"] == 42.0
+    assert stats["p99_response_time_ms"] == 42.0
+
+
+def test_list_records_sort_by_response_time_asc(client):
+    for v in [50.0, 10.0, 30.0]:
+        client.post(
+            "/api/v1/records",
+            json={
+                "endpoint": "https://sort.test",
+                "status_code": 200,
+                "response_time_ms": v,
+            },
+        )
+    resp = client.get("/api/v1/records?sort=response_time_ms&order=asc")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["sort"] == "response_time_ms"
+    assert data["order"] == "asc"
+    rts = [r["response_time_ms"] for r in data["records"]]
+    assert rts == [10.0, 30.0, 50.0]
+
+
+def test_list_records_sort_by_response_time_desc(client):
+    for v in [50.0, 10.0, 30.0]:
+        client.post(
+            "/api/v1/records",
+            json={
+                "endpoint": "https://sort.test",
+                "status_code": 200,
+                "response_time_ms": v,
+            },
+        )
+    rts = [r["response_time_ms"] for r in client.get(
+        "/api/v1/records?sort=response_time_ms&order=desc"
+    ).get_json()["records"]]
+    assert rts == [50.0, 30.0, 10.0]
+
+
+def test_list_records_sort_by_endpoint(client):
+    for ep in ["https://zebra.test", "https://apple.test", "https://mango.test"]:
+        client.post(
+            "/api/v1/records",
+            json={"endpoint": ep, "status_code": 200, "response_time_ms": 1.0},
+        )
+    eps = [r["endpoint"] for r in client.get(
+        "/api/v1/records?sort=endpoint"
+    ).get_json()["records"]]
+    assert eps == ["https://apple.test", "https://mango.test", "https://zebra.test"]
+
+
+def test_list_records_rejects_invalid_sort_field(client):
+    resp = client.get("/api/v1/records?sort=bogus")
+    assert resp.status_code == 400
+    assert "sort" in resp.get_json()["error"]
+
+
+def test_list_records_rejects_invalid_sort_order(client):
+    resp = client.get("/api/v1/records?order=sideways")
+    assert resp.status_code == 400
+    assert "order" in resp.get_json()["error"]
+
+
+def test_records_lock_concurrent_writes():
+    from app import health_records, records_lock
+    import threading as _threading
+
+    health_records.clear()
+
+    def writer(tag):
+        for i in range(40):
+            with records_lock:
+                health_records.append({
+                    "endpoint": f"https://{tag}.test",
+                    "status_code": 200,
+                    "response_time_ms": float(i),
+                    "checked_at": "2024-01-01T00:00:00+00:00",
+                    "healthy": True,
+                })
+
+    threads = [_threading.Thread(target=writer, args=(f"t{i}",)) for i in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(health_records) == 4 * 40


### PR DESCRIPTION
## 変更概要

- `services/analytics/app.py` の `health_records` を `threading.Lock` (`records_lock`) で保護(add/list/delete/report 全箇所)。読み取り時はスナップショットコピーを取得しロック保持時間を最小化
- `_percentile` ヘルパ（線形補間方式）を導入し、`/api/v1/report` のエンドポイント別統計に `p50_response_time_ms` / `p95_response_time_ms` / `p99_response_time_ms` を追加
- `GET /api/v1/records` に `sort`(`checked_at` / `endpoint` / `response_time_ms` / `status_code`)・`order`(`asc` / `desc`)パラメータを追加。不正値は 400。レスポンスにも `sort` / `order` を含める
- 上記をカバーするユニットテストを 8 件追加(67 → 75 件)

Closes #30

## 動作確認

- `cd services/analytics && python -m pytest test_app.py -q` → 75 件すべてパス
- `python -m flake8 app.py test_app.py --max-line-length=120` → 警告なし
- 既存 67 テストは互換性を保ったまま通過、追加 8 テストでパーセンタイル・ソート・並行 append のロス無しを検証
