### PR TITLE
fix+feat: analytics DELETE で JSON body 受領 + 時間範囲削除フィルタを追加

### DIFF
--- a/services/analytics/app.py
+++ b/services/analytics/app.py
@@ -310,23 +310,79 @@ def list_records():
     })
 
 
+def _get_delete_param(name: str, body: dict | None) -> str | None:
+    """Read a DELETE filter from query string first, then JSON body."""
+    value = request.args.get(name)
+    if value is not None:
+        return value
+    if body is not None and name in body and body[name] is not None:
+        return str(body[name])
+    return None
+
+
 @app.route("/api/v1/records", methods=["DELETE"])
 def delete_records():
-    endpoint = request.args.get("endpoint")
-    if not endpoint:
-        logger.warning("Delete request missing endpoint parameter")
-        return jsonify({"error": "Query parameter 'endpoint' is required"}), 400
+    body = request.get_json(silent=True) if request.is_json else None
+    if body is not None and not isinstance(body, dict):
+        body = None
+
+    endpoint = _get_delete_param("endpoint", body)
+    since_raw = _get_delete_param("since", body)
+    until_raw = _get_delete_param("until", body)
+    status_code_raw = _get_delete_param("status_code", body)
+    healthy_raw = _get_delete_param("healthy", body)
+
+    if not any([endpoint, since_raw, until_raw, status_code_raw, healthy_raw]):
+        logger.warning("Delete request missing all filters")
+        return jsonify({
+            "error": "At least one of 'endpoint', 'since', 'until', 'status_code', 'healthy' is required",
+        }), 400
+
+    since = until = None
+    try:
+        if since_raw is not None:
+            since = _parse_iso8601_arg(since_raw, "since")
+        if until_raw is not None:
+            until = _parse_iso8601_arg(until_raw, "until")
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+    if since is not None and until is not None and until < since:
+        return jsonify({"error": "Query parameter 'until' must be greater than or equal to 'since'"}), 400
+
+    status_code: int | None = None
+    if status_code_raw is not None:
+        try:
+            status_code = _parse_status_code_arg(status_code_raw, "status_code")
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
+
+    healthy: bool | None = None
+    if healthy_raw is not None:
+        try:
+            healthy = _parse_bool_arg(healthy_raw, "healthy")
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
 
     with records_lock:
-        before_count = len(health_records)
-        health_records[:] = [r for r in health_records if r["endpoint"] != endpoint]
-        deleted_count = before_count - len(health_records)
+        snapshot = list(health_records)
+        matches = _filter_records(snapshot, endpoint, since, until, healthy, status_code)
+        match_ids = {id(r) for r in matches}
+        remaining = [r for r in health_records if id(r) not in match_ids]
+        deleted_count = len(health_records) - len(remaining)
+        health_records[:] = remaining
 
     if deleted_count == 0:
-        logger.info("No records found for deletion: %s", endpoint)
-        return jsonify({"error": "No records found for the specified endpoint"}), 404
+        logger.info(
+            "No records found for delete filters: endpoint=%s since=%s until=%s status_code=%s healthy=%s",
+            endpoint, since_raw, until_raw, status_code_raw, healthy_raw,
+        )
+        return jsonify({"error": "No records found for the specified filters"}), 404
 
-    logger.info("Deleted %d records for endpoint=%s", deleted_count, endpoint)
+    logger.info(
+        "Deleted %d records (endpoint=%s since=%s until=%s status_code=%s healthy=%s)",
+        deleted_count, endpoint, since_raw, until_raw, status_code_raw, healthy_raw,
+    )
     return jsonify({"message": "Records deleted", "deleted_count": deleted_count})
 
 

--- a/services/analytics/test_app.py
+++ b/services/analytics/test_app.py
@@ -376,6 +376,149 @@ def test_delete_records_missing_param(client):
     assert "endpoint" in data["error"].lower()
 
 
+def test_delete_records_via_json_body():
+    """Gateway proxies DELETE with JSON body; analytics must accept it."""
+    from app import app as _app
+    c = _app.test_client()
+    c.post("/api/v1/records", json={
+        "endpoint": "https://body.example.com", "status_code": 200, "response_time_ms": 10,
+    })
+    resp = c.delete("/api/v1/records", json={"endpoint": "https://body.example.com"})
+    assert resp.status_code == 200
+    assert resp.get_json()["deleted_count"] == 1
+
+
+def test_delete_records_query_takes_precedence_over_body(client):
+    client.post("/api/v1/records", json={
+        "endpoint": "https://qs.example.com", "status_code": 200, "response_time_ms": 10,
+    })
+    client.post("/api/v1/records", json={
+        "endpoint": "https://body.example.com", "status_code": 200, "response_time_ms": 10,
+    })
+    resp = client.delete(
+        "/api/v1/records?endpoint=https://qs.example.com",
+        json={"endpoint": "https://body.example.com"},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["deleted_count"] == 1
+    list_resp = client.get("/api/v1/records")
+    endpoints = [r["endpoint"] for r in list_resp.get_json()["records"]]
+    assert "https://qs.example.com" not in endpoints
+    assert "https://body.example.com" in endpoints
+
+
+def test_delete_records_by_until(client):
+    client.post("/api/v1/records", json={
+        "endpoint": "https://old.com", "status_code": 200, "response_time_ms": 10,
+        "checked_at": "2025-01-01T00:00:00+00:00",
+    })
+    client.post("/api/v1/records", json={
+        "endpoint": "https://new.com", "status_code": 200, "response_time_ms": 10,
+        "checked_at": "2026-06-01T00:00:00+00:00",
+    })
+    resp = client.delete("/api/v1/records?until=2025-12-31T23:59:59%2B00:00")
+    assert resp.status_code == 200
+    assert resp.get_json()["deleted_count"] == 1
+    list_resp = client.get("/api/v1/records")
+    remaining = [r["endpoint"] for r in list_resp.get_json()["records"]]
+    assert remaining == ["https://new.com"]
+
+
+def test_delete_records_by_since(client):
+    client.post("/api/v1/records", json={
+        "endpoint": "https://old.com", "status_code": 200, "response_time_ms": 10,
+        "checked_at": "2025-01-01T00:00:00+00:00",
+    })
+    client.post("/api/v1/records", json={
+        "endpoint": "https://new.com", "status_code": 200, "response_time_ms": 10,
+        "checked_at": "2026-06-01T00:00:00+00:00",
+    })
+    resp = client.delete("/api/v1/records?since=2026-01-01T00:00:00%2B00:00")
+    assert resp.status_code == 200
+    assert resp.get_json()["deleted_count"] == 1
+    list_resp = client.get("/api/v1/records")
+    remaining = [r["endpoint"] for r in list_resp.get_json()["records"]]
+    assert remaining == ["https://old.com"]
+
+
+def test_delete_records_by_status_code(client):
+    client.post("/api/v1/records", json={
+        "endpoint": "https://x.com", "status_code": 500, "response_time_ms": 10,
+    })
+    client.post("/api/v1/records", json={
+        "endpoint": "https://y.com", "status_code": 200, "response_time_ms": 10,
+    })
+    resp = client.delete("/api/v1/records?status_code=500")
+    assert resp.status_code == 200
+    assert resp.get_json()["deleted_count"] == 1
+    list_resp = client.get("/api/v1/records")
+    remaining = [r["status_code"] for r in list_resp.get_json()["records"]]
+    assert remaining == [200]
+
+
+def test_delete_records_by_healthy_false(client):
+    client.post("/api/v1/records", json={
+        "endpoint": "https://up.com", "status_code": 200, "response_time_ms": 10,
+    })
+    client.post("/api/v1/records", json={
+        "endpoint": "https://down.com", "status_code": 503, "response_time_ms": 10,
+    })
+    resp = client.delete("/api/v1/records?healthy=false")
+    assert resp.status_code == 200
+    assert resp.get_json()["deleted_count"] == 1
+    list_resp = client.get("/api/v1/records")
+    remaining = [r["endpoint"] for r in list_resp.get_json()["records"]]
+    assert remaining == ["https://up.com"]
+
+
+def test_delete_records_combined_filters(client):
+    """Records matching ALL filters are deleted."""
+    client.post("/api/v1/records", json={
+        "endpoint": "https://api.com", "status_code": 500, "response_time_ms": 10,
+        "checked_at": "2025-01-01T00:00:00+00:00",
+    })
+    client.post("/api/v1/records", json={
+        "endpoint": "https://api.com", "status_code": 200, "response_time_ms": 10,
+        "checked_at": "2025-01-01T00:00:00+00:00",
+    })
+    client.post("/api/v1/records", json={
+        "endpoint": "https://other.com", "status_code": 500, "response_time_ms": 10,
+        "checked_at": "2025-01-01T00:00:00+00:00",
+    })
+    resp = client.delete(
+        "/api/v1/records?endpoint=https://api.com&status_code=500"
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["deleted_count"] == 1
+
+
+def test_delete_records_invalid_since(client):
+    resp = client.delete("/api/v1/records?since=not-a-date")
+    assert resp.status_code == 400
+    assert "since" in resp.get_json()["error"].lower()
+
+
+def test_delete_records_until_before_since(client):
+    resp = client.delete(
+        "/api/v1/records?since=2026-06-01T00:00:00%2B00:00&until=2025-01-01T00:00:00%2B00:00"
+    )
+    assert resp.status_code == 400
+
+
+def test_delete_records_invalid_status_code(client):
+    resp = client.delete("/api/v1/records?status_code=999")
+    assert resp.status_code == 400
+
+
+def test_delete_records_no_match_404(client):
+    client.post("/api/v1/records", json={
+        "endpoint": "https://existing.com", "status_code": 200, "response_time_ms": 10,
+    })
+    resp = client.delete("/api/v1/records?status_code=404")
+    assert resp.status_code == 404
+    assert "no records found" in resp.get_json()["error"].lower()
+
+
 def test_delete_records_preserves_other_endpoints(client):
     client.post("/api/v1/records", json={"endpoint": "https://a.com", "status_code": 200, "response_time_ms": 10})
     client.post("/api/v1/records", json={"endpoint": "https://b.com", "status_code": 200, "response_time_ms": 20})

--- a/services/gateway/src/app.test.ts
+++ b/services/gateway/src/app.test.ts
@@ -213,20 +213,50 @@ describe("Gateway Service", () => {
       expect(res.body.records).toEqual([]);
     });
 
-    it("should reject DELETE /api/v1/records without endpoint", async () => {
+    it("should reject DELETE /api/v1/records with no filters", async () => {
       const res = await request(app)
         .delete("/api/v1/records")
         .send({});
       expect(res.status).toBe(400);
       expect(res.body.error).toContain("endpoint");
+      expect(res.body.error).toContain("since");
+      expect(res.body.error).toContain("until");
     });
 
-    it("should proxy DELETE /api/v1/records", async () => {
+    it("should treat empty string field as missing", async () => {
+      const res = await request(app)
+        .delete("/api/v1/records")
+        .send({ endpoint: "" });
+      expect(res.status).toBe(400);
+    });
+
+    it("should proxy DELETE /api/v1/records by endpoint", async () => {
       const res = await request(app)
         .delete("/api/v1/records")
         .send({ endpoint: "https://example.com" });
       expect(res.status).toBe(200);
       expect(res.body.deleted).toBe(3);
+    });
+
+    it("should proxy DELETE /api/v1/records by until", async () => {
+      const res = await request(app)
+        .delete("/api/v1/records")
+        .send({ until: "2025-01-01T00:00:00Z" });
+      expect(res.status).toBe(200);
+    });
+
+    it("should proxy DELETE /api/v1/records by status_code", async () => {
+      const res = await request(app)
+        .delete("/api/v1/records")
+        .send({ status_code: 500 });
+      expect(res.status).toBe(200);
+    });
+
+    it("should proxy DELETE /api/v1/records by healthy", async () => {
+      const res = await request(app)
+        .delete("/api/v1/records")
+        .send({ healthy: false });
+      expect(res.status).toBe(200);
     });
 
     it("should proxy GET /api/v1/report", async () => {

--- a/services/gateway/src/app.ts
+++ b/services/gateway/src/app.ts
@@ -156,14 +156,32 @@ app.get("/api/v1/records", async (req: Request, res: Response, next: NextFunctio
   }
 });
 
+const DELETE_FILTER_FIELDS = [
+  "endpoint",
+  "since",
+  "until",
+  "status_code",
+  "healthy",
+] as const;
+
 app.delete("/api/v1/records", async (req: Request, res: Response, next: NextFunction) => {
   try {
-    if (!req.body.endpoint) {
-      res.status(400).json({ error: "Field 'endpoint' is required" });
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const hasAnyFilter = DELETE_FILTER_FIELDS.some(
+      (field) => body[field] !== undefined && body[field] !== null && body[field] !== "",
+    );
+    if (!hasAnyFilter) {
+      res.status(400).json({
+        error: `At least one of: ${DELETE_FILTER_FIELDS.join(", ")} is required`,
+      });
       return;
     }
-    const result = await proxyRequest(analyticsUrl(), "/api/v1/records", "DELETE", req.body);
-    logger.info(`Deleted records for endpoint: ${req.body.endpoint}`);
+    const result = await proxyRequest(analyticsUrl(), "/api/v1/records", "DELETE", body);
+    const summary = DELETE_FILTER_FIELDS
+      .filter((f) => body[f] !== undefined && body[f] !== null && body[f] !== "")
+      .map((f) => `${f}=${String(body[f])}`)
+      .join(", ");
+    logger.info(`Deleted records with filters: ${summary}`);
     res.status(result.status).json(result.data);
   } catch (err) {
     next(err);


### PR DESCRIPTION
## 変更概要

### バグ修正

- gateway は `DELETE /api/v1/records` を JSON body で proxy していたが、analytics 側はクエリ文字列専用だったため運用環境で 400 になっていた。
- analytics に `_get_delete_param` ヘルパを追加し「クエリ → JSON body」の順で読むよう修正（クエリが優先）。

### 機能追加（retention 用途）

- analytics `DELETE /api/v1/records` を `endpoint` / `since` / `until` / `status_code` / `healthy` のいずれか 1 つ以上で実行可能に拡張。複数指定時は AND 結合。`_filter_records` を再利用しロジックを統一。
- gateway DELETE を「5 種フィルタのいずれか必須」に変更し、空文字も未指定扱い。ログに適用フィルタを記録。

### テスト

- analytics: 11 件追加（JSON body 受領、クエリ優先、since/until/status_code/healthy 単独、複合フィルタ、各種バリデーション、404）
- gateway: 6 件追加（フィルタ未指定 400、空文字、since/until/status_code/healthy 通過）

Closes #32

## 動作確認手順

```
# Python
cd services/analytics
pip install -r requirements.txt
pytest -v   # 86 passed
flake8 --max-line-length=120 app.py test_app.py

# TypeScript
cd services/gateway
npm install && npm test   # 21 passed
npx eslint src/ && npx tsc --noEmit
```