### PR TITLE
feat(analytics): records/report に min/max_response_time_ms フィルタを追加

### DIFF
--- a/services/analytics/app.py
+++ b/services/analytics/app.py
@@ -188,6 +188,24 @@ def _parse_status_code_arg(value: str, name: str) -> int:
     return parsed
 
 
+def _parse_response_time_arg(value: str, name: str) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as e:
+        raise ValueError(
+            f"Query parameter '{name}' must be a number"
+        ) from e
+    if not math.isfinite(parsed):
+        raise ValueError(
+            f"Query parameter '{name}' must be a finite number"
+        )
+    if parsed < 0:
+        raise ValueError(
+            f"Query parameter '{name}' must be non-negative"
+        )
+    return parsed
+
+
 def _filter_records(
     records: list[dict],
     endpoint: str | None,
@@ -195,6 +213,8 @@ def _filter_records(
     until: datetime | None,
     healthy: bool | None,
     status_code: int | None = None,
+    min_response_time_ms: float | None = None,
+    max_response_time_ms: float | None = None,
 ) -> list[dict]:
     filtered = records
     if endpoint:
@@ -203,6 +223,16 @@ def _filter_records(
         filtered = [r for r in filtered if bool(r.get("healthy")) == healthy]
     if status_code is not None:
         filtered = [r for r in filtered if r.get("status_code") == status_code]
+    if min_response_time_ms is not None:
+        filtered = [
+            r for r in filtered
+            if r.get("response_time_ms", 0.0) >= min_response_time_ms
+        ]
+    if max_response_time_ms is not None:
+        filtered = [
+            r for r in filtered
+            if r.get("response_time_ms", 0.0) <= max_response_time_ms
+        ]
     if since is not None or until is not None:
         narrowed = []
         for r in filtered:
@@ -227,6 +257,8 @@ def list_records():
     until_raw = request.args.get("until")
     healthy_raw = request.args.get("healthy")
     status_code_raw = request.args.get("status_code")
+    min_rt_raw = request.args.get("min_response_time_ms")
+    max_rt_raw = request.args.get("max_response_time_ms")
 
     if limit_raw is None:
         limit = LIST_DEFAULT_LIMIT
@@ -276,6 +308,32 @@ def list_records():
         except ValueError as e:
             return jsonify({"error": str(e)}), 400
 
+    min_response_time_ms: float | None = None
+    max_response_time_ms: float | None = None
+    try:
+        if min_rt_raw is not None:
+            min_response_time_ms = _parse_response_time_arg(
+                min_rt_raw, "min_response_time_ms",
+            )
+        if max_rt_raw is not None:
+            max_response_time_ms = _parse_response_time_arg(
+                max_rt_raw, "max_response_time_ms",
+            )
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+    if (
+        min_response_time_ms is not None
+        and max_response_time_ms is not None
+        and max_response_time_ms < min_response_time_ms
+    ):
+        return jsonify({
+            "error": (
+                "Query parameter 'max_response_time_ms' must be "
+                "greater than or equal to 'min_response_time_ms'"
+            ),
+        }), 400
+
     sort_field = request.args.get("sort", "checked_at")
     sort_order = request.args.get("order", "asc")
     if sort_field not in ALLOWED_SORT_FIELDS:
@@ -289,7 +347,11 @@ def list_records():
 
     with records_lock:
         snapshot = list(health_records)
-    filtered = _filter_records(snapshot, endpoint, since, until, healthy, status_code)
+    filtered = _filter_records(
+        snapshot, endpoint, since, until, healthy, status_code,
+        min_response_time_ms=min_response_time_ms,
+        max_response_time_ms=max_response_time_ms,
+    )
 
     reverse = sort_order == "desc"
     filtered.sort(key=lambda r: r.get(sort_field, ""), reverse=reverse)
@@ -393,6 +455,8 @@ def report():
     until_raw = request.args.get("until")
     healthy_raw = request.args.get("healthy")
     status_code_raw = request.args.get("status_code")
+    min_rt_raw = request.args.get("min_response_time_ms")
+    max_rt_raw = request.args.get("max_response_time_ms")
 
     since = until = None
     try:
@@ -420,9 +484,39 @@ def report():
         except ValueError as e:
             return jsonify({"error": str(e)}), 400
 
+    min_response_time_ms: float | None = None
+    max_response_time_ms: float | None = None
+    try:
+        if min_rt_raw is not None:
+            min_response_time_ms = _parse_response_time_arg(
+                min_rt_raw, "min_response_time_ms",
+            )
+        if max_rt_raw is not None:
+            max_response_time_ms = _parse_response_time_arg(
+                max_rt_raw, "max_response_time_ms",
+            )
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+    if (
+        min_response_time_ms is not None
+        and max_response_time_ms is not None
+        and max_response_time_ms < min_response_time_ms
+    ):
+        return jsonify({
+            "error": (
+                "Query parameter 'max_response_time_ms' must be "
+                "greater than or equal to 'min_response_time_ms'"
+            ),
+        }), 400
+
     with records_lock:
         snapshot = list(health_records)
-    filtered = _filter_records(snapshot, endpoint_filter, since, until, healthy, status_code)
+    filtered = _filter_records(
+        snapshot, endpoint_filter, since, until, healthy, status_code,
+        min_response_time_ms=min_response_time_ms,
+        max_response_time_ms=max_response_time_ms,
+    )
 
     if not filtered:
         return jsonify({"message": "No records available", "endpoints": {}})

--- a/services/analytics/test_app.py
+++ b/services/analytics/test_app.py
@@ -940,3 +940,131 @@ def test_records_lock_concurrent_writes():
         t.join()
 
     assert len(health_records) == 4 * 40
+
+
+# --- min/max_response_time_ms filter ---
+
+
+def _seed_response_times(client):
+    for rt in [50.0, 150.0, 250.0, 500.0, 1000.0]:
+        client.post("/api/v1/records", json={
+            "endpoint": "https://example.com",
+            "status_code": 200,
+            "response_time_ms": rt,
+        })
+
+
+def test_records_min_response_time_filter(client):
+    _seed_response_times(client)
+    resp = client.get("/api/v1/records?min_response_time_ms=200")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    times = sorted(r["response_time_ms"] for r in data["records"])
+    assert times == [250.0, 500.0, 1000.0]
+
+
+def test_records_max_response_time_filter(client):
+    _seed_response_times(client)
+    resp = client.get("/api/v1/records?max_response_time_ms=200")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    times = sorted(r["response_time_ms"] for r in data["records"])
+    assert times == [50.0, 150.0]
+
+
+def test_records_response_time_range_filter(client):
+    _seed_response_times(client)
+    resp = client.get(
+        "/api/v1/records?min_response_time_ms=100&max_response_time_ms=400"
+    )
+    data = resp.get_json()
+    times = sorted(r["response_time_ms"] for r in data["records"])
+    assert times == [150.0, 250.0]
+
+
+def test_records_response_time_inclusive_boundaries(client):
+    _seed_response_times(client)
+    resp = client.get(
+        "/api/v1/records?min_response_time_ms=150&max_response_time_ms=500"
+    )
+    data = resp.get_json()
+    times = sorted(r["response_time_ms"] for r in data["records"])
+    assert times == [150.0, 250.0, 500.0]
+
+
+def test_records_min_response_time_invalid(client):
+    cases = [
+        "/api/v1/records?min_response_time_ms=abc",
+        "/api/v1/records?min_response_time_ms=-1",
+        "/api/v1/records?min_response_time_ms=inf",
+        "/api/v1/records?min_response_time_ms=nan",
+    ]
+    for url in cases:
+        resp = client.get(url)
+        assert resp.status_code == 400, f"expected 400 for {url}"
+
+
+def test_records_max_response_time_invalid(client):
+    resp = client.get("/api/v1/records?max_response_time_ms=xyz")
+    assert resp.status_code == 400
+
+
+def test_records_max_less_than_min(client):
+    resp = client.get(
+        "/api/v1/records?min_response_time_ms=200&max_response_time_ms=100"
+    )
+    assert resp.status_code == 400
+    assert "max_response_time_ms" in resp.get_json()["error"]
+
+
+def test_records_response_time_combined_with_endpoint(client):
+    client.post("/api/v1/records", json={
+        "endpoint": "https://a.example.com", "status_code": 200, "response_time_ms": 100,
+    })
+    client.post("/api/v1/records", json={
+        "endpoint": "https://a.example.com", "status_code": 200, "response_time_ms": 300,
+    })
+    client.post("/api/v1/records", json={
+        "endpoint": "https://b.example.com", "status_code": 200, "response_time_ms": 300,
+    })
+    resp = client.get(
+        "/api/v1/records?endpoint=https://a.example.com&min_response_time_ms=200"
+    )
+    data = resp.get_json()
+    assert data["total"] == 1
+    assert data["records"][0]["response_time_ms"] == 300
+
+
+def test_report_min_response_time_filter(client):
+    _seed_response_times(client)
+    resp = client.get("/api/v1/report?min_response_time_ms=300")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    ep_data = data["endpoints"]["https://example.com"]
+    assert ep_data["total_checks"] == 2
+    assert ep_data["min_response_time_ms"] == 500.0
+    assert ep_data["max_response_time_ms"] == 1000.0
+
+
+def test_report_response_time_range(client):
+    _seed_response_times(client)
+    resp = client.get(
+        "/api/v1/report?min_response_time_ms=100&max_response_time_ms=600"
+    )
+    data = resp.get_json()
+    ep_data = data["endpoints"]["https://example.com"]
+    assert ep_data["total_checks"] == 3
+    assert ep_data["min_response_time_ms"] == 150.0
+    assert ep_data["max_response_time_ms"] == 500.0
+
+
+def test_report_max_less_than_min_returns_400(client):
+    resp = client.get(
+        "/api/v1/report?min_response_time_ms=500&max_response_time_ms=100"
+    )
+    assert resp.status_code == 400
+
+
+def test_report_response_time_invalid(client):
+    resp = client.get("/api/v1/report?min_response_time_ms=bad")
+    assert resp.status_code == 400


### PR DESCRIPTION
## 概要

- `GET /api/v1/records` と `GET /api/v1/report` に応答時間レンジフィルタを追加
- 遅延・SLO 違反調査やパフォーマンス分析が `/api/v1/records` の全件取得→クライアント側絞り込み無しで済むようになる

## 追加クエリパラメータ

- `min_response_time_ms`: この値以上（>=）の `response_time_ms` を持つレコードに絞り込む
- `max_response_time_ms`: この値以下（<=）の `response_time_ms` を持つレコードに絞り込む
- 数値・有限・非負のみ受け付け、`max < min` は 400
- 既存の `endpoint` / `since` / `until` / `healthy` / `status_code` と組み合わせ可

## 変更ファイル

- `services/analytics/app.py`
- `services/analytics/test_app.py`

## 動作確認

- `flake8 --max-line-length=120 app.py test_app.py` がパス
- `pytest -q` で全 98 件パス（新規 12 件を含む）

Closes #36